### PR TITLE
Formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +125,7 @@ dependencies = [
  "clap",
  "directories",
  "rand",
+ "regex",
  "serde",
  "serde_json",
 ]
@@ -175,6 +185,12 @@ name = "libc"
 version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+
+[[package]]
+name = "memchr"
+version = "2.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "option-ext"
@@ -255,6 +271,35 @@ dependencies = [
  "redox_syscall",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ anyhow = "1.0.75"
 rand = "0.8.5"
 serde = { version = "1.0.189", features = ["derive"] }
 serde_json = "1.0.107"
+regex = "1"

--- a/src/clash.rs
+++ b/src/clash.rs
@@ -1,5 +1,7 @@
 use serde::{Serialize, Deserialize};
-use regex::Regex;
+
+mod formatter;
+use formatter::Formatter;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Clash {
@@ -50,73 +52,6 @@ struct ClashTestCase {
     test_out: String,
     #[serde(rename = "isValidator")]
     is_validator: bool,
-}
-
-struct Formatter {
-    re_variable: Regex,
-    re_constant: Regex,
-    re_bold: Regex,
-    re_monospace: Regex,
-
-    fmt_variable: String, 
-    fmt_constant: String, 
-    fmt_bold: String, 
-    fmt_monospace: String, 
-}
-
-impl Formatter {
-    // TODO: finish support `Monospace` (Newline trimming)
-    // For testing `Monospace`: 23214afcdb23616e230097d138bd872ea7c75
-    // TODO: support nested formatting <<Next [[n]] lines:>>
-
-    fn new() -> Self {
-        Formatter {
-            re_variable: Regex::new(r"\[\[([^\]]+)\]\]").unwrap(),
-            re_constant: Regex::new(r"\{\{([^\}]+)\}\}").unwrap(),
-            re_bold: Regex::new(r"<<([^>]+)>>").unwrap(),
-            // Also capture the previous '\n' if any (`Monospace` rule)
-            re_monospace: Regex::new(r"\n?`([^`]+)`").unwrap(),
-
-            fmt_variable:  "\x1b[33m".to_string(),    // Yellow
-            fmt_constant:  "\x1b[34m".to_string(),    // Blue
-            fmt_bold:      "\x1b[3;39m".to_string(),  // Italics
-            fmt_monospace: "\x1b[39;49m".to_string(), // Do nothing for the moment
-        }
-    }
-
-    fn format(&self, text: &str) -> String {
-        // Trim consecutive spaces (imitates html behaviour)
-        // But only if it's not in a Monospace block (between backticks ``)
-        let re_backtick = Regex::new(r"`([^`]+)`|([^`]+)").unwrap();
-        let re_spaces = Regex::new(r" +").unwrap();
-
-        let _trimmed_spaces = re_backtick.replace_all(text, |caps: &regex::Captures| {
-            if let Some(backtick_text) = caps.get(1) {
-                backtick_text.as_str().to_string()
-            } else if let Some(non_backtick_text) = caps.get(2) {
-                re_spaces.replace_all(non_backtick_text.as_str(), " ").to_string()
-            } else {
-                "".to_string()
-            }
-        }).as_bytes().to_vec();
-        let trimmed_spaces = std::str::from_utf8(&_trimmed_spaces).unwrap();
-
-        let formatted_var = self.re_variable.replace_all(trimmed_spaces, |caps: &regex::Captures| {
-            format!("{}{}\x1b[39;49m", &self.fmt_variable, &caps[1])
-        });
-        let formatted_con = self.re_constant.replace_all(&formatted_var, |caps: &regex::Captures| {
-            format!("{}{}\x1b[39;49m", &self.fmt_constant, &caps[1])
-        });
-        let formatted_bold = self.re_bold.replace_all(&formatted_con, |caps: &regex::Captures| {
-            format!("{}{}\x1b[0;0m", &self.fmt_bold, &caps[1])
-        });
-
-        let formatted_mono = self.re_monospace.replace_all(&formatted_bold, |caps: &regex::Captures| {
-            // Extra newline at the start for monospace
-            format!("\n{}{}\x1b[39;49m", &self.fmt_monospace, &caps[1])
-        });
-        return formatted_mono.to_string();
-    }
 }
 
 impl Clash {

--- a/src/clash.rs
+++ b/src/clash.rs
@@ -1,4 +1,5 @@
 use serde::{Serialize, Deserialize};
+use regex::Regex;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Clash {
@@ -51,14 +52,124 @@ struct ClashTestCase {
     is_validator: bool,
 }
 
+struct Formatter {
+    re_variable: Regex,
+    re_constant: Regex,
+    re_bold: Regex,
+    re_monospace: Regex,
+
+    fmt_variable: String, 
+    fmt_constant: String, 
+    fmt_bold: String, 
+    fmt_monospace: String, 
+}
+
+impl Formatter {
+    // TODO: finish support `Monospace` (Newline trimming)
+    // TODO: support nested formatting <<Next [[n]] lines:>>
+
+    fn new() -> Self {
+        Formatter {
+            re_variable: Regex::new(r"\[\[([^\]]+)\]\]").unwrap(),
+            re_constant: Regex::new(r"\{\{([^\}]+)\}\}").unwrap(),
+            re_bold: Regex::new(r"<<([^>]+)>>").unwrap(),
+            re_monospace: Regex::new(r"`([^`]+)`").unwrap(),
+
+            fmt_variable:  "\x1b[33m".to_string(),    // Yellow
+            fmt_constant:  "\x1b[34m".to_string(),    // Blue
+            fmt_bold:      "\x1b[3;39m".to_string(),  // Italics
+            fmt_monospace: "\x1b[39;49m".to_string(), // Do nothing for the moment
+        }
+    }
+
+    fn format(&self, text: &str) -> String {
+        let formatted_var = self.re_variable.replace_all(&text, |caps: &regex::Captures| {
+            format!("{}{}\x1b[39;49m", &self.fmt_variable, &caps[1])
+        });
+        let formatted_con = self.re_constant.replace_all(&formatted_var, |caps: &regex::Captures| {
+            format!("{}{}\x1b[39;49m", &self.fmt_constant, &caps[1])
+        });
+        let formatted_bold = self.re_bold.replace_all(&formatted_con, |caps: &regex::Captures| {
+            format!("{}{}\x1b[0;0m", &self.fmt_bold, &caps[1])
+        });
+        let formatted_mono = self.re_monospace.replace_all(&formatted_bold, |caps: &regex::Captures| {
+            // Extra newline at the start for monospace (have to do some extra trimming)
+            format!("\n{}{}\x1b[39;49m", &self.fmt_monospace, &caps[1])
+        });
+        return formatted_mono.to_string();
+    }
+}
+
 impl Clash {
     pub fn pretty_print(&self) {
-        let cdata = &self.last_version.data;
-        println!("\x1b[34;47m=== {} ===\x1b[39;49m\n", cdata.title);
-        println!("https://www.codingame.com/contribute/view/{}\n", self.public_handle);
-        println!("{}\n", cdata.statement);
-        println!("Constraints:\n{}\n", cdata.constraints);
-        println!("Input:\n{}\n", cdata.input_description);
-        println!("Output:\n{}\n", cdata.output_description);
-    }
+        use std::io::Write;
+
+        let cdata: &ClashData = &self.last_version.data;
+
+        // TODO: --no-color flag
+        let with_color = true;
+
+        let mut buf: Vec<u8> = Vec::new();
+
+        // Trim consecutive spaces (imitates html behaviour)
+        // But only if it's not in a Monospace block (between backticks ``)
+        let re_backtick = Regex::new(r"`([^`]+)`|([^`]+)").unwrap();
+        let re_spaces = Regex::new(r" +").unwrap();
+        let text_str = std::str::from_utf8(&buf).expect("Invalid UTF-8");
+
+        let trimmed = re_backtick.replace_all(text_str, |caps: &regex::Captures| {
+            if let Some(backtick_text) = caps.get(1) {
+                backtick_text.as_str().to_string()
+            } else if let Some(non_backtick_text) = caps.get(2) {
+                re_spaces.replace_all(non_backtick_text.as_str(), " ").to_string()
+            } else {
+                "".to_string()
+            }
+        });
+        buf = trimmed.as_bytes().to_vec();
+    
+        // Title and link
+        writeln!(&mut buf, "\x1b[33m=== {} ===\x1b[39;49m\n", cdata.title).unwrap();
+        writeln!(&mut buf, "\x1b[1;33mhttps://www.codingame.com/contribute/view/{}\x1b[0;0m\n", self.public_handle).unwrap();
+
+        // Statement
+        if with_color {
+            let formatter = Formatter::new();
+            let section_color = "\x1b[33m".to_string(); // Yellow
+    
+            writeln!(&mut buf, "{}\n", formatter.format(&cdata.statement)).unwrap();
+            writeln!(&mut buf, "{}Constraints:\x1b[39;49m", section_color).unwrap();
+            writeln!(&mut buf, "{}\n", formatter.format(&cdata.constraints)).unwrap();
+            writeln!(&mut buf, "{}Input:\x1b[39;49m", section_color).unwrap();
+            writeln!(&mut buf, "{}\n", formatter.format(&cdata.input_description)).unwrap();
+            writeln!(&mut buf, "{}Output:\x1b[39;49m", section_color).unwrap();
+            writeln!(&mut buf, "{}\n", formatter.format(&cdata.output_description)).unwrap();
+        } else {
+            writeln!(&mut buf, "{}\n", cdata.statement).unwrap();
+            writeln!(&mut buf, "Constraints:").unwrap();
+            writeln!(&mut buf, "{}\n", cdata.constraints).unwrap();
+            writeln!(&mut buf, "Input:").unwrap();
+            writeln!(&mut buf, "{}\n", cdata.input_description).unwrap();
+            writeln!(&mut buf, "Output:").unwrap();
+            writeln!(&mut buf, "{}\n", cdata.output_description).unwrap();
+        }
+
+        // Example testcase
+        if !cdata.testcases.is_empty() {
+            let example: &ClashTestCase = &cdata.testcases[0];
+            let example_in: &String = &example.test_in;
+            let example_out: &String = &example.test_out;
+    
+            writeln!(&mut buf, "\x1b[33mExample:\x1b[39;49m").unwrap();
+            writeln!(&mut buf, "{}\n", &example_in).unwrap();
+            writeln!(&mut buf, "\x1b[1;32m{}\x1b[39;49m", &example_out).unwrap();
+        } else {
+            // This should probably be a breaking error
+            writeln!(&mut buf, "No testcases available.").unwrap();
+        }
+    
+        let out_str = String::from_utf8_lossy(&buf).to_string();
+        // dbg!(out_str.clone());
+        println!("{}", out_str);
+    }    
 }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -67,3 +67,139 @@ impl Formatter {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trim_spaces_with_format() {
+        let formatter = Formatter::new();
+        let text = "hello  world";
+
+        assert_eq!(formatter.format(text), "hello world");
+    }
+
+    #[test]
+    fn does_not_trim_spaces_in_monospace() {
+        let formatter = Formatter::new();
+        let text = "`{\n    let x = 5;\n}`";
+
+        assert!(formatter.format(text).contains("{\n    let x = 5;\n}"));
+    }
+
+    #[test]
+    fn format_bold_text() {
+        let formatter = Formatter::new();
+        let text = "Regular <<very bold>> text";
+        let formatted_text = formatter.format(text);
+
+        assert!(!formatted_text.contains("<<"));
+        assert!(formatted_text.contains(&formatter.fmt_bold));
+    }
+
+    #[test]
+    fn format_tricky_bold_text() {
+        let formatter = Formatter::new();
+        let text = "In life <<the trick is to realize that 2 > 3>>";
+        let formatted_text = formatter.format(text);
+
+        assert!(!formatted_text.contains("<<"));
+        assert!(formatted_text.contains(&formatter.fmt_bold));
+    }
+
+    #[test]
+    fn format_constants() {
+        let formatter = Formatter::new();
+        let text = "Some values {{never ever}} change";
+        let formatted_text = formatter.format(text);
+
+        assert!(!formatted_text.contains("{{"));
+        assert!(formatted_text.contains(&formatter.fmt_constant));
+    }
+
+    #[test]
+    fn format_tricky_constants() {
+        let formatter = Formatter::new();
+        let text = "When Santa smiles it looks like {{ :} }}";
+        let formatted_text = formatter.format(text);
+
+        assert!(!formatted_text.contains("{{"));
+        assert!(formatted_text.contains(&formatter.fmt_constant));
+    }
+
+    #[test]
+    fn format_variables() {
+        let formatter = Formatter::new();
+        let text = "The correct value of [[x]] is something you won't find";
+        let formatted_text = formatter.format(text);
+
+        assert!(!formatted_text.contains("[["));
+        assert!(formatted_text.contains(&formatter.fmt_variable));
+    }
+
+    #[test]
+    fn format_tricky_variables() {
+        let formatter = Formatter::new();
+        let text = "Vector item [[v[1]]] is nil if len is 1";
+        let formatted_text = formatter.format(text);
+
+        assert!(!formatted_text.contains("[["));
+        assert!(formatted_text.contains(&formatter.fmt_variable));
+    }
+
+    #[test]
+    fn format_monospace() {
+        let formatter = Formatter::new();
+        let text = "To create a new variable use `let x = 5`";
+        let formatted_text = formatter.format(text);
+
+        assert!(!formatted_text.contains("`"));
+    }
+
+    #[test]
+    fn format_monospace_adds_newline_if_there_is_none() {
+        let formatter = Formatter::new();
+        let text = "I have `no whitespace`";
+        let formatted_text = formatter.format(text);
+
+        assert!(formatted_text.contains("\n"));
+    }
+
+    #[test]
+    fn format_monospace_does_not_add_additional_newlines() {
+        let formatter = Formatter::new();
+        let text = "I have \n\n`lots of whitespace`";
+        let formatted_text = formatter.format(text);
+
+        assert!(!formatted_text.contains("\n\n\n"));
+    }
+
+    #[test]
+    fn nest_variable_and_constant_in_bold() {
+        let formatter = Formatter::new();
+        let text = "Some things <<are {{bold}}, some others are [[extra]]>>";
+        let formatted_text = formatter.format(text);
+
+        assert!(!formatted_text.contains("<<"));
+        assert!(formatted_text.contains(&formatter.fmt_bold));
+        assert!(!formatted_text.contains("{{"));
+        assert!(formatted_text.contains(&formatter.fmt_constant));
+        assert!(!formatted_text.contains("[["));
+        assert!(formatted_text.contains(&formatter.fmt_variable));
+    }
+
+    #[test]
+    fn nest_constant_and_variable_in_monospace() {
+        let formatter = Formatter::new();
+        let text = "`[[status]] = {{EXCELLENT}}.freeze`";
+        let formatted_text = formatter.format(text);
+
+        assert!(!formatted_text.contains("{{"));
+        assert!(formatted_text.contains(&formatter.fmt_constant));
+        assert!(!formatted_text.contains("[["));
+        assert!(formatted_text.contains(&formatter.fmt_variable));
+
+        assert!(!formatted_text.contains("`"));
+    }
+}
+

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -35,7 +35,7 @@ impl Formatter {
     pub fn format(&self, text: &str) -> String {
         // Trim consecutive spaces (imitates html behaviour)
         // But only if it's not in a Monospace block (between backticks ``)
-        let re_backtick = Regex::new(r"`([^`]+)`|([^`]+)").unwrap();
+        let re_backtick = Regex::new(r"(`[^`]+`)|([^`]+)").unwrap();
         let re_spaces = Regex::new(r" +").unwrap();
 
         let _trimmed_spaces = re_backtick.replace_all(text, |caps: &regex::Captures| {

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,0 +1,69 @@
+use regex::Regex;
+
+pub struct Formatter {
+    re_variable: Regex,
+    re_constant: Regex,
+    re_bold: Regex,
+    re_monospace: Regex,
+
+    fmt_variable: String, 
+    fmt_constant: String, 
+    fmt_bold: String, 
+    fmt_monospace: String, 
+}
+
+impl Formatter {
+    // TODO: finish support `Monospace` (Newline trimming)
+    // For testing `Monospace`: 23214afcdb23616e230097d138bd872ea7c75
+    // TODO: support nested formatting <<Next [[n]] lines:>>
+
+    pub fn new() -> Self {
+        Formatter {
+            re_variable: Regex::new(r"\[\[([^\]]+)\]\]").unwrap(),
+            re_constant: Regex::new(r"\{\{([^\}]+)\}\}").unwrap(),
+            re_bold: Regex::new(r"<<([^>]+)>>").unwrap(),
+            // Also capture the previous '\n' if any (`Monospace` rule)
+            re_monospace: Regex::new(r"\n?`([^`]+)`").unwrap(),
+
+            fmt_variable:  "\x1b[33m".to_string(),    // Yellow
+            fmt_constant:  "\x1b[34m".to_string(),    // Blue
+            fmt_bold:      "\x1b[3;39m".to_string(),  // Italics
+            fmt_monospace: "\x1b[39;49m".to_string(), // Do nothing for the moment
+        }
+    }
+
+    pub fn format(&self, text: &str) -> String {
+        // Trim consecutive spaces (imitates html behaviour)
+        // But only if it's not in a Monospace block (between backticks ``)
+        let re_backtick = Regex::new(r"`([^`]+)`|([^`]+)").unwrap();
+        let re_spaces = Regex::new(r" +").unwrap();
+
+        let _trimmed_spaces = re_backtick.replace_all(text, |caps: &regex::Captures| {
+            if let Some(backtick_text) = caps.get(1) {
+                backtick_text.as_str().to_string()
+            } else if let Some(non_backtick_text) = caps.get(2) {
+                re_spaces.replace_all(non_backtick_text.as_str(), " ").to_string()
+            } else {
+                "".to_string()
+            }
+        }).as_bytes().to_vec();
+        let trimmed_spaces = std::str::from_utf8(&_trimmed_spaces).unwrap();
+
+        let formatted_var = self.re_variable.replace_all(trimmed_spaces, |caps: &regex::Captures| {
+            format!("{}{}\x1b[39;49m", &self.fmt_variable, &caps[1])
+        });
+        let formatted_con = self.re_constant.replace_all(&formatted_var, |caps: &regex::Captures| {
+            format!("{}{}\x1b[39;49m", &self.fmt_constant, &caps[1])
+        });
+        let formatted_bold = self.re_bold.replace_all(&formatted_con, |caps: &regex::Captures| {
+            format!("{}{}\x1b[0;0m", &self.fmt_bold, &caps[1])
+        });
+
+        let formatted_mono = self.re_monospace.replace_all(&formatted_bold, |caps: &regex::Captures| {
+            // Extra newline at the start for monospace
+            format!("\n{}{}\x1b[39;49m", &self.fmt_monospace, &caps[1])
+        });
+        return formatted_mono.to_string();
+    }
+}
+

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -19,9 +19,9 @@ impl Formatter {
 
     pub fn new() -> Self {
         Formatter {
-            re_variable: Regex::new(r"\[\[([^\]]+)\]\]").unwrap(),
-            re_constant: Regex::new(r"\{\{([^\}]+)\}\}").unwrap(),
-            re_bold: Regex::new(r"<<([^>]+)>>").unwrap(),
+            re_variable: Regex::new(r"\[\[(.+?)\]\]").unwrap(),
+            re_constant: Regex::new(r"\{\{(.+?)\}\}").unwrap(),
+            re_bold: Regex::new(r"<<(.+?)>>").unwrap(),
             // Also capture the previous '\n' if any (`Monospace` rule)
             re_monospace: Regex::new(r"\n?`([^`]+)`").unwrap(),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,13 +77,14 @@ impl App {
 
     fn show(&self, args: &ArgMatches) -> Result<()> {
         let handle = self.handle_from_args(args).or_else(|_| self.current_handle())?;
+        println!("https://www.codingame.com/contribute/view/{}", handle);
         let clash_file = self.clash_dir.join(format!("{}.json", handle));
         let contents = std::fs::read_to_string(clash_file)
         .with_context(|| format!("Unable to find clash with handle {}", handle))?;
         let clash: Clash = serde_json::from_str(&contents)?;
         // DEBUG
         // dbg!(contents);
-        println!("{}", serde_json::to_string_pretty(&clash).unwrap());
+        // println!("{}", serde_json::to_string_pretty(&clash).unwrap());
         clash.pretty_print();
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@ use directories::ProjectDirs;
 use rand::seq::IteratorRandom;
 use std::path::PathBuf;
 use serde_json;
-mod clash;
 
 use clash::Clash;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,8 +81,9 @@ impl App {
         let contents = std::fs::read_to_string(clash_file)
         .with_context(|| format!("Unable to find clash with handle {}", handle))?;
         let clash: Clash = serde_json::from_str(&contents)?;
+        // DEBUG
         // dbg!(contents);
-        // println!("{}", serde_json::to_string(&clash)?);
+        println!("{}", serde_json::to_string_pretty(&clash).unwrap());
         clash.pretty_print();
         Ok(())
     }
@@ -109,6 +110,7 @@ impl App {
 }
 
 fn main() -> Result<()> {
+    // We look for the locally stored clashes here:
     let project_dirs =
         ProjectDirs::from("com", "Clash CLI", "clash").expect("Unable to find project directory");
 


### PR DESCRIPTION
- Added an example testcase to the show command.
- Variables, constants, bold and monospace are formatted.
- Trims consecutive spaces if it's not in a monospace block.