### PR TITLE
Fix missing statement html

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,0 +1,90 @@
+use clap::ArgMatches;
+use std::path::PathBuf;
+use anyhow::{anyhow, Context, Result};
+use rand::seq::IteratorRandom;
+use crate::Clash;
+
+#[derive(Debug, Clone)]
+struct PublicHandle(String);
+impl std::fmt::Display for PublicHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+pub struct App {
+    pub clash_dir: PathBuf,
+    pub current_clash_file: PathBuf,
+}
+
+impl App {
+    pub fn new(data_dir: &std::path::Path) -> App {
+        App {
+            clash_dir: data_dir.join("clashes"),
+            current_clash_file: data_dir.join("current"),
+        }
+    }
+
+    fn current_handle(&self) -> Result<PublicHandle> {
+        let content = std::fs::read_to_string(&self.current_clash_file)
+            .with_context(|| format!("Unable to read {:?}", &self.current_clash_file))?;
+        Ok(PublicHandle(content))
+    }
+
+    fn handle_from_args(&self, args: &ArgMatches) -> Result<PublicHandle> {
+        match args.get_one::<String>("PUBLIC_HANDLE") {
+            Some(s) => Ok(PublicHandle(s.to_owned())),
+            None => Err(anyhow!("No clash handle given")),
+        }
+    }
+
+    fn clashes(&self) -> Result<std::fs::ReadDir> {
+        std::fs::read_dir(&self.clash_dir).with_context(|| "No clashes stored")
+    }
+
+    fn random_handle(&self) -> Result<PublicHandle> {
+        let mut rng = rand::thread_rng();
+        if let Ok(entry) = self.clashes()?.choose(&mut rng).expect("No clashes to choose from!") {
+            let filename = entry.file_name().into_string().expect("unable to convert OsString to String (?!?)");
+            Ok(PublicHandle(match filename.strip_suffix(".json") {
+                Some(handle) => handle.to_string(),
+                None => filename,
+            }))
+        } else {
+            Err(anyhow!("Unable to randomize next clash"))
+        }
+    }
+
+    pub fn show(&self, args: &ArgMatches) -> Result<()> {
+        let handle = self.handle_from_args(args).or_else(|_| self.current_handle())?;
+        let clash_file = self.clash_dir.join(format!("{}.json", handle));
+        let contents = std::fs::read_to_string(clash_file)
+        .with_context(|| format!("Unable to find clash with handle {}", handle))?;
+        let clash: Clash = serde_json::from_str(&contents)?;
+        // dbg!(contents);
+        // println!("{}", serde_json::to_string(&clash)?);
+        clash.pretty_print();
+        Ok(())
+    }
+
+    pub fn next(&self, args: &ArgMatches) -> Result<()> {
+        let next_handle = self
+            .handle_from_args(args)
+            .or_else(|_| self.random_handle())?;
+        println!("{:?}", next_handle);
+        std::fs::write(&self.current_clash_file, next_handle.to_string())?;
+        Ok(())
+    }
+
+    pub fn status(&self, _args: &ArgMatches) -> Result<()> {
+        println!("Current clash file: {}", self.current_clash_file.display());
+        match self.current_handle() {
+            Ok(handle) => println!("Current clash: {}", handle),
+            _ => println!("Current clash: -"),
+        }
+        println!("Clash dir: {}", self.clash_dir.display());
+        println!("Number of clashes: {}", self.clashes()?.count());
+        Ok(())
+    }
+}
+

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,7 +18,7 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(data_dir: &std::path::Path) -> App {
+    fn new(data_dir: &std::path::Path) -> App {
         App {
             clash_dir: data_dir.join("clashes"),
             current_clash_file: data_dir.join("current"),
@@ -44,8 +44,15 @@ impl App {
 
     fn random_handle(&self) -> Result<PublicHandle> {
         let mut rng = rand::thread_rng();
-        if let Ok(entry) = self.clashes()?.choose(&mut rng).expect("No clashes to choose from!") {
-            let filename = entry.file_name().into_string().expect("unable to convert OsString to String (?!?)");
+        if let Ok(entry) = self
+            .clashes()?
+            .choose(&mut rng)
+            .expect("No clashes to choose from!")
+        {
+            let filename = entry
+                .file_name()
+                .into_string()
+                .expect("unable to convert OsString to String (?!?)");
             Ok(PublicHandle(match filename.strip_suffix(".json") {
                 Some(handle) => handle.to_string(),
                 None => filename,
@@ -55,14 +62,28 @@ impl App {
         }
     }
 
+    fn read_clash(&self, handle: &PublicHandle) -> Result<Clash> {
+        let clash_file = self.clash_dir.join(format!("{}.json", handle));
+        let contents = std::fs::read_to_string(&clash_file)
+            .with_context(|| format!("Unable to find clash with handle {}", handle))?;
+        let clash: Clash = serde_json::from_str(&contents)
+            .with_context(|| format!("Unable to deserialize clash from {:?}", &clash_file))?;
+        Ok(clash)
+    }
+
     pub fn show(&self, args: &ArgMatches) -> Result<()> {
         let handle = self.handle_from_args(args).or_else(|_| self.current_handle())?;
         let clash_file = self.clash_dir.join(format!("{}.json", handle));
         let contents = std::fs::read_to_string(clash_file)
-        .with_context(|| format!("Unable to find clash with handle {}", handle))?;
+            .with_context(|| format!("Unable to find clash with handle {}", handle))?;
+        if args.get_flag("raw") {
+            println!("{}", &contents);
+            return Ok(())
+        }
         let clash: Clash = serde_json::from_str(&contents)?;
+        // DEBUG
         // dbg!(contents);
-        // println!("{}", serde_json::to_string(&clash)?);
+        // println!("{}", serde_json::to_string_pretty(&clash).unwrap());
         clash.pretty_print();
         Ok(())
     }
@@ -71,7 +92,8 @@ impl App {
         let next_handle = self
             .handle_from_args(args)
             .or_else(|_| self.random_handle())?;
-        println!("{:?}", next_handle);
+        println!("Changed clash to https://codingame.com/contribute/view/{}", next_handle);
+        println!(" Local file: {}/{}.json", &self.clash_dir.to_str().unwrap(), next_handle);
         std::fs::write(&self.current_clash_file, next_handle.to_string())?;
         Ok(())
     }
@@ -80,10 +102,93 @@ impl App {
         println!("Current clash file: {}", self.current_clash_file.display());
         match self.current_handle() {
             Ok(handle) => println!("Current clash: {}", handle),
-            _ => println!("Current clash: -"),
+            Err(_) => println!("Current clash: -"),
         }
         println!("Clash dir: {}", self.clash_dir.display());
-        println!("Number of clashes: {}", self.clashes()?.count());
+        let num_clashes = match self.clashes() {
+            Ok(clashes) => clashes.count(),
+            Err(_) => 0,
+        };
+        println!("Number of clashes: {}", num_clashes);
+        Ok(())
+    }
+
+    pub fn run(&self, args: &ArgMatches) -> Result<()> {
+        let handle = self
+            .handle_from_args(args)
+            .or_else(|_| self.current_handle())?;
+
+        // Run build
+        if let Some(build_cmd) = args.get_one::<String>("build-command") {
+            match shlex::split(build_cmd) {
+                Some(shlexed_build_cmd) if shlexed_build_cmd.len() > 0 => {
+                    let exe = &shlexed_build_cmd[0];
+                    let exe_args = &shlexed_build_cmd[1..];
+                    let build = std::process::Command::new(exe).args(exe_args).output().with_context(|| format!("Unable to run build-command '{}'", exe))?;
+                    if !build.status.success() {
+                        if build.stderr.len() > 0 {
+                            println!("Build command STDERR:\n{}", String::from_utf8(build.stderr)?);
+                        }
+                        if build.stdout.len() > 0 {
+                            println!("Build command STDOUT:\n{}", String::from_utf8(build.stdout)?);
+                        }
+                        return Err(anyhow!("Build failed"));
+                    }
+                }
+                _ => return Err(anyhow!("Invalid --build-command")),
+            };
+        }
+
+        // Run tests
+        if let Some(run_cmd) = args.get_one::<String>("command") {
+            match shlex::split(run_cmd) {
+                Some(shlexed_run_cmd) if shlexed_run_cmd.len() > 0 => {
+                    let exe = &shlexed_run_cmd[0];
+                    let exe_args = &shlexed_run_cmd[1..];
+                    let mut run = std::process::Command::new(exe);
+                    let run = run.args(exe_args);
+                    let clash = self.read_clash(&handle)?;
+                    let ignore_failures = args.get_flag("ignore-failures");
+                    let mut num_passed = 0;
+                    let total = clash.testcases().len();
+                    for testcase in clash.testcases() {
+                        match run_test(run, testcase)? {
+                            TestRunResult::Success => { num_passed += 1; },
+                            TestRunResult::WrongOutput{stderr, stdout} => {
+                                if stderr.len() > 0 {
+                                    println!("stderr   : {}", stderr);
+                                }
+                                println!("{}", testcase.title);
+                                println!("==== EXPECTED ==\n{}", testcase.test_out);
+                                println!("===== ACTUAL ===\n{}", stdout);
+                                if !ignore_failures {
+                                    break;
+                                }
+                            },
+                            TestRunResult::RuntimeError{stderr} => {
+                                println!("{}", stderr);
+                                if !ignore_failures {
+                                    break;
+                                }
+                            },
+                        }
+                    }
+                    if num_passed == total {
+                        println!("{}/{} tests passed!", num_passed, total);
+                        // Move on to next clash if --auto-advance is set
+                        if args.get_flag("auto-advance") {
+                            let next_handle = self.random_handle()?;
+                            std::fs::write(&self.current_clash_file, next_handle.to_string())?;
+                            println!("Moving on to next clash...");
+                        }
+                    } else {
+                        println!("{}/{} tests passed", num_passed, total);
+                    }
+                }
+                _ => return Err(anyhow!("Invalid --command")),
+            }
+        }
+
         Ok(())
     }
 }

--- a/src/clash.rs
+++ b/src/clash.rs
@@ -1,4 +1,5 @@
 use serde::{Serialize, Deserialize};
+mod app;
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -56,5 +57,29 @@ impl Clash {
         println!("Constraints:\n{}\n", cdata.constraints);
         println!("Input:\n{}\n", cdata.input_description);
         println!("Output:\n{}\n", cdata.output_description);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use app::App;
+    use directories::ProjectDirs;
+
+    fn app() -> App {
+        let project_dirs = ProjectDirs::from("com", "Clash CLI", "clash")
+            .expect("Unable to find project directory");
+        App::new(project_dirs.data_dir())
+    }
+
+    fn decimal_fraction_percentage_clash() -> String {
+        let clash_file = app().clash_dir.join("58951a69f66d23586be8084cb0969c637b07.json");
+        std::fs::read_to_string(clash_file)
+            .expect("Cannot find test for clash. Please run status command.")
+    }
+
+    #[test]
+    fn do_not_panic_when_missing_statement_html() {
+        serde_json::from_str::<Clash>(&decimal_fraction_percentage_clash()).unwrap();
     }
 }

--- a/src/clash.rs
+++ b/src/clash.rs
@@ -1,17 +1,19 @@
-use serde::{Serialize, Deserialize};
+use serde::{Serialize, Deserialize, Deserializer};
+
+mod formatter;
+use formatter::Formatter;
 mod app;
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Clash {
     id: u32,
-    nickname: String,
     public_handle: String,
     last_version: ClashVersion,
     #[serde(rename = "upVotes")]
-    upvotes: u32,
+    upvotes: i32,
     #[serde(rename = "downVotes")]
-    downvotes: u32,
+    downvotes: i32,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -19,22 +21,27 @@ pub struct Clash {
 struct ClashVersion {
     version: u32,
     data: ClashData,
-    #[serde(default)] // statementHtml may not always exist
-    statement_html: String,
+    statement_html: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ClashData {
     title: String,
+
+    // apparently some of these fields are missing in very old clashes, default to false
+    #[serde(default)]
     fastest: bool,
+    #[serde(default)]
     reverse: bool,
+    #[serde(default)]
     shortest: bool,
+
     statement: String,
     #[serde(rename = "testCases")]
     testcases: Vec<ClashTestCase>,
-    constraints: String,
-    stub_generator: String,
+    constraints: Option<String>,
+    stub_generator: Option<String>,
     input_description: String,
     output_description: String,
 }
@@ -42,22 +49,94 @@ struct ClashData {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ClashTestCase {
+    #[serde(deserialize_with = "deserialize_testcase_title")]
     title: String,
     test_in: String,
     test_out: String,
     is_validator: bool,
 }
 
-impl Clash {
-    pub fn pretty_print(&self) {
-        let cdata = &self.last_version.data;
-        println!("\x1b[34;47m=== {} ===\x1b[39;49m\n", cdata.title);
-        println!("https://www.codingame.com/contribute/view/{}\n", self.public_handle);
-        println!("{}\n", cdata.statement);
-        println!("Constraints:\n{}\n", cdata.constraints);
-        println!("Input:\n{}\n", cdata.input_description);
-        println!("Output:\n{}\n", cdata.output_description);
+// Workaround for some old clashes which have testcase title as
+// { "title": { "2": "The Actual Title" } } for whatever reason
+fn deserialize_testcase_title<'de, D: Deserializer<'de>>(de: D) -> Result<String, D::Error> {
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum TempTitle {
+        Normal(String),
+        Weird {
+            #[serde(rename = "2")]
+            title: String
+        },
     }
+    let title = match TempTitle::deserialize(de)? {
+        TempTitle::Normal(title) => title,
+        TempTitle::Weird {title} => title
+    };
+    Ok(title)
+}
+
+impl Clash {
+    pub fn testcases(&self) -> &Vec<ClashTestCase> {
+        &self.last_version.data.testcases
+    }
+    pub fn pretty_print(&self) {
+        use std::io::Write;
+
+        let cdata: &ClashData = &self.last_version.data;
+
+        // TODO: --no-color flag
+        let with_color = true;
+
+        let mut buf: Vec<u8> = Vec::new();
+    
+        // Title and link
+        writeln!(&mut buf, "\x1b[33m=== {} ===\x1b[39;49m\n", cdata.title).unwrap();
+        writeln!(&mut buf, "\x1b[1;33mhttps://www.codingame.com/contribute/view/{}\x1b[0;0m\n", self.public_handle).unwrap();
+
+        // Statement
+        if with_color {
+            let formatter = Formatter::new();
+            let section_color = "\x1b[33m".to_string(); // Yellow
+    
+            writeln!(&mut buf, "{}\n", formatter.format(&cdata.statement)).unwrap();
+            if let Some(constraints) = &cdata.constraints {
+                writeln!(&mut buf, "{}Constraints:\x1b[39;49m", section_color).unwrap();
+                writeln!(&mut buf, "{}\n", formatter.format(&constraints)).unwrap();
+            }
+            writeln!(&mut buf, "{}Input:\x1b[39;49m", section_color).unwrap();
+            writeln!(&mut buf, "{}\n", formatter.format(&cdata.input_description)).unwrap();
+            writeln!(&mut buf, "{}Output:\x1b[39;49m", section_color).unwrap();
+            writeln!(&mut buf, "{}\n", formatter.format(&cdata.output_description)).unwrap();
+        } else {
+            writeln!(&mut buf, "{}\n", cdata.statement).unwrap();
+            if let Some(constraints) = &cdata.constraints {
+                writeln!(&mut buf, "Constraints:").unwrap();
+                writeln!(&mut buf, "{}\n", constraints).unwrap();
+            }
+            writeln!(&mut buf, "Input:").unwrap();
+            writeln!(&mut buf, "{}\n", cdata.input_description).unwrap();
+            writeln!(&mut buf, "Output:").unwrap();
+            writeln!(&mut buf, "{}\n", cdata.output_description).unwrap();
+        }
+
+        // Example testcase
+        if !cdata.testcases.is_empty() {
+            let example: &ClashTestCase = &cdata.testcases[0];
+            let example_in: &String = &example.test_in;
+            let example_out: &String = &example.test_out;
+    
+            writeln!(&mut buf, "\x1b[33mExample:\x1b[39;49m").unwrap();
+            writeln!(&mut buf, "{}\n", &example_in).unwrap();
+            writeln!(&mut buf, "\x1b[1;32m{}\x1b[39;49m", &example_out).unwrap();
+        } else {
+            // This should probably be a breaking error
+            writeln!(&mut buf, "No testcases available.").unwrap();
+        }
+    
+        let out_str = String::from_utf8_lossy(&buf).to_string();
+        // dbg!(out_str.clone());
+        println!("{}", out_str);
+    }    
 }
 
 #[cfg(test)]

--- a/src/clash.rs
+++ b/src/clash.rs
@@ -1,12 +1,11 @@
 use serde::{Serialize, Deserialize};
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Clash {
     id: u32,
     nickname: String,
-    #[serde(rename = "publicHandle")]
     public_handle: String,
-    #[serde(rename = "lastVersion")]
     last_version: ClashVersion,
     #[serde(rename = "upVotes")]
     upvotes: u32,
@@ -15,14 +14,16 @@ pub struct Clash {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct ClashVersion {
     version: u32,
     data: ClashData,
-    #[serde(rename = "statementHTML", default)]
+    #[serde(default)] // statementHtml may not always exist
     statement_html: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct ClashData {
     title: String,
     fastest: bool,
@@ -32,22 +33,17 @@ struct ClashData {
     #[serde(rename = "testCases")]
     testcases: Vec<ClashTestCase>,
     constraints: String,
-    #[serde(rename = "stubGenerator")]
     stub_generator: String,
-    #[serde(rename = "inputDescription")]
     input_description: String,
-    #[serde(rename = "outputDescription")]
     output_description: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct ClashTestCase {
     title: String,
-    #[serde(rename = "testIn")]
     test_in: String,
-    #[serde(rename = "testOut")]
     test_out: String,
-    #[serde(rename = "isValidator")]
     is_validator: bool,
 }
 

--- a/src/clash.rs
+++ b/src/clash.rs
@@ -18,7 +18,7 @@ pub struct Clash {
 struct ClashVersion {
     version: u32,
     data: ClashData,
-    #[serde(rename = "statementHTML")]
+    #[serde(rename = "statementHTML", default)]
     statement_html: String,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,10 @@
-use anyhow::{anyhow, Context, Result};
-use clap::{arg, ArgMatches, Command};
+use clap::{arg, Command};
 use directories::ProjectDirs;
-use rand::seq::IteratorRandom;
-use std::path::PathBuf;
-use serde_json;
-mod clash;
+use anyhow::Result;
 
+mod app;
 use clash::Clash;
+use app::App;
 
 fn cli() -> Command {
     Command::new("clash")
@@ -22,90 +20,6 @@ fn cli() -> Command {
                 .arg(arg!([PUBLIC_HANDLE] "hexadecimal handle of the clash")),
         )
         .subcommand(Command::new("status").about("Show status information"))
-}
-
-#[derive(Debug, Clone)]
-struct PublicHandle(String);
-impl std::fmt::Display for PublicHandle {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-struct App {
-    clash_dir: PathBuf,
-    current_clash_file: PathBuf,
-}
-
-impl App {
-    fn new(data_dir: &std::path::Path) -> App {
-        App {
-            clash_dir: data_dir.join("clashes"),
-            current_clash_file: data_dir.join("current"),
-        }
-    }
-
-    fn current_handle(&self) -> Result<PublicHandle> {
-        let content = std::fs::read_to_string(&self.current_clash_file)
-            .with_context(|| format!("Unable to read {:?}", &self.current_clash_file))?;
-        Ok(PublicHandle(content))
-    }
-
-    fn handle_from_args(&self, args: &ArgMatches) -> Result<PublicHandle> {
-        match args.get_one::<String>("PUBLIC_HANDLE") {
-            Some(s) => Ok(PublicHandle(s.to_owned())),
-            None => Err(anyhow!("No clash handle given")),
-        }
-    }
-
-    fn clashes(&self) -> Result<std::fs::ReadDir> {
-        std::fs::read_dir(&self.clash_dir).with_context(|| "No clashes stored")
-    }
-
-    fn random_handle(&self) -> Result<PublicHandle> {
-        let mut rng = rand::thread_rng();
-        if let Ok(entry) = self.clashes()?.choose(&mut rng).expect("No clashes to choose from!") {
-            let filename = entry.file_name().into_string().expect("unable to convert OsString to String (?!?)");
-            Ok(PublicHandle(match filename.strip_suffix(".json") {
-                Some(handle) => handle.to_string(),
-                None => filename,
-            }))
-        } else {
-            Err(anyhow!("Unable to randomize next clash"))
-        }
-    }
-
-    fn show(&self, args: &ArgMatches) -> Result<()> {
-        let handle = self.handle_from_args(args).or_else(|_| self.current_handle())?;
-        let clash_file = self.clash_dir.join(format!("{}.json", handle));
-        let contents = std::fs::read_to_string(clash_file)
-        .with_context(|| format!("Unable to find clash with handle {}", handle))?;
-        let clash: Clash = serde_json::from_str(&contents)?;
-        // dbg!(contents);
-        // println!("{}", serde_json::to_string(&clash)?);
-        clash.pretty_print();
-        Ok(())
-    }
-
-    fn next(&self, args: &ArgMatches) -> Result<()> {
-        let next_handle = self
-            .handle_from_args(args)
-            .or_else(|_| self.random_handle())?;
-        println!("{:?}", next_handle);
-        std::fs::write(&self.current_clash_file, next_handle.to_string())?;
-        Ok(())
-    }
-
-    fn status(&self, _args: &ArgMatches) -> Result<()> {
-        println!("Current clash file: {}", self.current_clash_file.display());
-        match self.current_handle() {
-            Ok(handle) => println!("Current clash: {}", handle),
-            _ => println!("Current clash: -"),
-        }
-        println!("Clash dir: {}", self.clash_dir.display());
-        println!("Number of clashes: {}", self.clashes()?.count());
-        Ok(())
-    }
 }
 
 fn main() -> Result<()> {


### PR DESCRIPTION
Some clashes do not have a `statementHtml` key (try `cargo show 58951a69f66d23586be8084cb0969c637b07`).

This PR fixes this issue and tests it, along the way breaks out the App struct into its own file to make it usable in tests.