### PR TITLE
Formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +208,7 @@ checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 name = "clash"
 version = "0.1.0"
 dependencies = [
+ "ansi_term",
  "anyhow",
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ shlex = "1.2.0"
 regex = "1"
 reqwest = { version = "0.11.22", features = ["blocking"] }
 clap_complete = "4.4.3"
+ansi_term = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,6 @@ name = "clash"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-path = "src/clash.rs"
-
 [dependencies]
 clap = { version = "4.4.6", features = ["derive", "cargo"] }
 directories = "5.0"

--- a/src/clash.rs
+++ b/src/clash.rs
@@ -1,5 +1,6 @@
 use serde::{Serialize, Deserialize, Deserializer};
-use regex::Regex;
+use ansi_term::Style;
+use ansi_term::Colour;
 
 mod formatter;
 use formatter::Formatter;
@@ -100,61 +101,53 @@ impl Clash {
         let cdata: &ClashData = &self.last_version.data;
 
         // TODO: --no-color flag
-        let with_color = true;
+        let with_color = false;
+        let formatter = Formatter::new(with_color);
 
         let mut buf: Vec<u8> = Vec::new();
     
         // Title and link
-        writeln!(&mut buf, "\x1b[33m=== {} ===\x1b[39;49m\n", cdata.title).unwrap();
-        writeln!(&mut buf, "\x1b[1;33mhttps://www.codingame.com/contribute/view/{}\x1b[0;0m\n", self.public_handle).unwrap();
+        let intro_colour = if with_color {
+            Style::new().fg(Colour::Yellow)
+        } else {
+            Style::default()
+        };
+        writeln!(
+            &mut buf, "{}\n",
+            intro_colour.paint(format!("=== {} ===", &cdata.title))
+        ).unwrap();
+        writeln!(
+            &mut buf, "{}\n",
+            intro_colour.bold().paint(format!(
+                "https://www.codingame.com/contribute/view/{}", self.public_handle)
+            )
+        ).unwrap();
 
         // Statement
-        if with_color {
-            let formatter = Formatter::new();
-            let section_color = "\x1b[33m".to_string(); // Yellow
-    
-            writeln!(&mut buf, "{}\n", formatter.format(&cdata.statement)).unwrap();
-            writeln!(&mut buf, "{}Input:\x1b[39;49m", section_color).unwrap();
-            writeln!(&mut buf, "{}\n", formatter.format(&cdata.input_description)).unwrap();
-            writeln!(&mut buf, "{}Output:\x1b[39;49m", section_color).unwrap();
-            writeln!(&mut buf, "{}\n", formatter.format(&cdata.output_description)).unwrap();
-            if let Some(constraints) = &cdata.constraints {
-                writeln!(&mut buf, "{}Constraints:\x1b[39;49m", section_color).unwrap();
-                writeln!(&mut buf, "{}\n", formatter.format(&constraints)).unwrap();
-            }
+        let titles_colour = if with_color {
+            Style::new().fg(Colour::Yellow)
         } else {
-            writeln!(&mut buf, "{}\n", cdata.statement).unwrap();
-            writeln!(&mut buf, "Input:").unwrap();
-            writeln!(&mut buf, "{}\n", cdata.input_description).unwrap();
-            writeln!(&mut buf, "Output:").unwrap();
-            writeln!(&mut buf, "{}\n", cdata.output_description).unwrap();
-            if let Some(constraints) = &cdata.constraints {
-                writeln!(&mut buf, "Constraints:").unwrap();
-                writeln!(&mut buf, "{}\n", constraints).unwrap();
-            }
+            Style::default()
+        };
+        writeln!(&mut buf, "{}\n", formatter.format(&cdata.statement)).unwrap();
+        writeln!(&mut buf, "{}", titles_colour.paint("Input:")).unwrap();
+        writeln!(&mut buf, "{}\n", formatter.format(&cdata.input_description)).unwrap();
+        writeln!(&mut buf, "{}", titles_colour.paint("Output:")).unwrap();
+        writeln!(&mut buf, "{}\n", formatter.format(&cdata.output_description)).unwrap();
+        if let Some(constraints) = &cdata.constraints {
+            writeln!(&mut buf, "{}", titles_colour.paint("Constraints:")).unwrap();
+            writeln!(&mut buf, "{}\n", formatter.format(&constraints)).unwrap();
         }
 
         // Example testcase
-        if !cdata.testcases.is_empty() {
-            let example: &ClashTestCase = &cdata.testcases[0];
-            let example_in: &String = &example.test_in;
-            let example_out: &String = &example.test_out;
-
-            // For visibility: turn spaces into dim "•" and newlines into dim "¶"
-            let visual_example_in = Regex::new(r"\n")
-              .unwrap()
-              .replace_all(&example_in, "\x1b[2m¶\n\x1b[0m");
-            let visual_example_in = Regex::new(r" ")
-              .unwrap()
-              .replace_all(&visual_example_in, "\x1b[2m•\x1b[0m");
-
-            writeln!(&mut buf, "\x1b[33mExample:\x1b[39;49m").unwrap();
-            writeln!(&mut buf, "{}\n", &visual_example_in).unwrap();
-            writeln!(&mut buf, "\x1b[1;32m{}\x1b[39;49m", &example_out).unwrap();
-        } else {
-            // This should probably be a breaking error
-            writeln!(&mut buf, "No testcases available.").unwrap();
-        }
+        let example: &ClashTestCase = &cdata.testcases[0];
+        writeln!(&mut buf, "{}", titles_colour.paint("Example:")).unwrap();
+        writeln!(&mut buf, "{}\n", &formatter.add_visibility(
+            &example.test_in, Style::default())
+        ).unwrap();
+        writeln!(&mut buf, "{}", &formatter.add_visibility(
+            &example.test_out, Style::new().bold().fg(Colour::Green))
+        ).unwrap();
     
         let out_str = String::from_utf8_lossy(&buf).to_string();
         // dbg!(out_str.clone());

--- a/src/clash.rs
+++ b/src/clash.rs
@@ -1,4 +1,5 @@
 use serde::{Serialize, Deserialize, Deserializer};
+use regex::Regex;
 
 mod formatter;
 use formatter::Formatter;
@@ -129,8 +130,16 @@ impl Clash {
             let example_in: &String = &example.test_in;
             let example_out: &String = &example.test_out;
 
+            // For visibility: turn spaces into dim "•" and newlines into dim "¶"
+            let visual_example_in = Regex::new(r"\n")
+              .unwrap()
+              .replace_all(&example_in, "\x1b[2m¶\n\x1b[0m");
+            let visual_example_in = Regex::new(r" ")
+              .unwrap()
+              .replace_all(&visual_example_in, "\x1b[2m•\x1b[0m");
+
             writeln!(&mut buf, "\x1b[33mExample:\x1b[39;49m").unwrap();
-            writeln!(&mut buf, "{}\n", &example_in).unwrap();
+            writeln!(&mut buf, "{}\n", &visual_example_in).unwrap();
             writeln!(&mut buf, "\x1b[1;32m{}\x1b[39;49m", &example_out).unwrap();
         } else {
             // This should probably be a breaking error

--- a/src/clash.rs
+++ b/src/clash.rs
@@ -114,24 +114,24 @@ impl Clash {
             let section_color = "\x1b[33m".to_string(); // Yellow
     
             writeln!(&mut buf, "{}\n", formatter.format(&cdata.statement)).unwrap();
-            if let Some(constraints) = &cdata.constraints {
-                writeln!(&mut buf, "{}Constraints:\x1b[39;49m", section_color).unwrap();
-                writeln!(&mut buf, "{}\n", formatter.format(&constraints)).unwrap();
-            }
             writeln!(&mut buf, "{}Input:\x1b[39;49m", section_color).unwrap();
             writeln!(&mut buf, "{}\n", formatter.format(&cdata.input_description)).unwrap();
             writeln!(&mut buf, "{}Output:\x1b[39;49m", section_color).unwrap();
             writeln!(&mut buf, "{}\n", formatter.format(&cdata.output_description)).unwrap();
+            if let Some(constraints) = &cdata.constraints {
+                writeln!(&mut buf, "{}Constraints:\x1b[39;49m", section_color).unwrap();
+                writeln!(&mut buf, "{}\n", formatter.format(&constraints)).unwrap();
+            }
         } else {
             writeln!(&mut buf, "{}\n", cdata.statement).unwrap();
-            if let Some(constraints) = &cdata.constraints {
-                writeln!(&mut buf, "Constraints:").unwrap();
-                writeln!(&mut buf, "{}\n", constraints).unwrap();
-            }
             writeln!(&mut buf, "Input:").unwrap();
             writeln!(&mut buf, "{}\n", cdata.input_description).unwrap();
             writeln!(&mut buf, "Output:").unwrap();
             writeln!(&mut buf, "{}\n", cdata.output_description).unwrap();
+            if let Some(constraints) = &cdata.constraints {
+                writeln!(&mut buf, "Constraints:").unwrap();
+                writeln!(&mut buf, "{}\n", constraints).unwrap();
+            }
         }
 
         // Example testcase

--- a/src/clash.rs
+++ b/src/clash.rs
@@ -1,4 +1,5 @@
 use serde::{Serialize, Deserialize};
+use regex::Regex;
 
 mod formatter;
 use formatter::Formatter;
@@ -96,9 +97,17 @@ impl Clash {
             let example: &ClashTestCase = &cdata.testcases[0];
             let example_in: &String = &example.test_in;
             let example_out: &String = &example.test_out;
+
+            // For visibility: turn spaces into dim "•" and newlines into dim "¶"
+            let visual_example_in = Regex::new(r"\n")
+              .unwrap()
+              .replace_all(&example_in, "\x1b[2m¶\n\x1b[0m");
+            let visual_example_in = Regex::new(r" ")
+              .unwrap()
+              .replace_all(&visual_example_in, "\x1b[2m•\x1b[0m");
     
             writeln!(&mut buf, "\x1b[33mExample:\x1b[39;49m").unwrap();
-            writeln!(&mut buf, "{}\n", &example_in).unwrap();
+            writeln!(&mut buf, "{}\n", &visual_example_in).unwrap();
             writeln!(&mut buf, "\x1b[1;32m{}\x1b[39;49m", &example_out).unwrap();
         } else {
             // This should probably be a breaking error

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,46 +1,37 @@
-use regex::Regex;
+use crate::outputstyle::OutputStyle;
 use ansi_term::Style;
-use ansi_term::Colour;
+use regex::Regex;
 
 pub struct Formatter {
-    colour_mode: bool,
+    use_colors: bool,
 
     re_variable: Regex,
     re_constant: Regex,
     re_bold: Regex,
     re_monospace: Regex,
-
-    fmt_variable: Colour, 
-    fmt_constant: Colour, 
-    fmt_bold: Style, 
-    fmt_monospace: Style, 
 }
 
-impl Formatter {
-    // TODO: finish support `Monospace` (Newline trimming)
-    // For testing `Monospace`: 23214afcdb23616e230097d138bd872ea7c75
-    // TODO: support nested formatting <<Next [[n]] lines:>>
-
-    pub fn new(colour_mode: bool) -> Self {
+impl Default for Formatter {
+    fn default() -> Self {
         Formatter {
-            colour_mode,
+            use_colors: true,
 
             re_variable:  Regex::new(r"\[\[(.+?)\]\]").unwrap(),
             re_constant:  Regex::new(r"\{\{(.+?)\}\}").unwrap(),
             re_bold:      Regex::new(r"<<(.+?)>>").unwrap(),
             // Also capture the previous '\n' if any (`Monospace` rule)
             re_monospace: Regex::new(r"\n?`([^`]+)`").unwrap(),
-
-            fmt_variable:  Colour::Yellow,
-            fmt_constant:  Colour::Blue,
-            fmt_bold:      Style::new().italic(),
-            fmt_monospace: Style::default(), // Do nothing for the moment
         }
     }
+}
 
-    pub fn format(&self, text: &str) -> String {
+impl Formatter {
+    // TODO: finish support `Monospace` (Newline trimming)
+    // For testing `Monospace`: 23214afcdb23616e230097d138bd872ea7c75
+    // TODO: support nested formatting <<Next [[n]] lines:>>
+    pub fn format(&self, text: &str, output_style: &OutputStyle) -> String {
         // Don't need to do nothing if --no-color is on
-        if !self.colour_mode {
+        if !self.use_colors {
             return text.to_string();
         }
 
@@ -48,7 +39,8 @@ impl Formatter {
         // But only if it's not in a Monospace block (between backticks ``)
         let re_backtick = Regex::new(r"(`[^`]+`)|([^`]+)").unwrap();
         let re_spaces = Regex::new(r" +").unwrap();
-        let _trimmed_spaces = re_backtick.replace_all(text, |caps: &regex::Captures| {
+
+        let mut result = re_backtick.replace_all(text, |caps: &regex::Captures| {
             if let Some(backtick_text) = caps.get(1) {
                 backtick_text.as_str().to_string()
             } else if let Some(non_backtick_text) = caps.get(2) {
@@ -56,47 +48,48 @@ impl Formatter {
             } else {
                 "".to_string()
             }
-        }).as_bytes().to_vec();
-        let trimmed_spaces = std::str::from_utf8(&_trimmed_spaces).unwrap();
+        }).to_string();
 
         // Replace codingame formatting with proper colours
-        let formatted_var = self.re_variable.replace_all(trimmed_spaces, |caps: &regex::Captures| {
-            self.fmt_variable.paint(&caps[1]).to_string()
-        });
-        let formatted_con = self.re_constant.replace_all(&formatted_var, |caps: &regex::Captures| {
-            self.fmt_constant.paint(&caps[1]).to_string()
-        });
-        let formatted_bold = self.re_bold.replace_all(&formatted_con, |caps: &regex::Captures| {
-            self.fmt_bold.paint(&caps[1]).to_string()
-        });
-        let formatted_mono = self.re_monospace.replace_all(&formatted_bold, |caps: &regex::Captures| {
-            // Extra newline at the start for monospace
-            format!("\n{}", &self.fmt_monospace.paint(&caps[1]).to_string())
-        });
+        if let Some(style) = output_style.variable {
+            result = self.re_variable.replace_all(&result, |caps: &regex::Captures| {
+                style.paint(&caps[1]).to_string()
+            }).to_string();
+        }
+        if let Some(style) = output_style.constant {
+            result = self.re_constant.replace_all(&result, |caps: &regex::Captures| {
+                style.paint(&caps[1]).to_string()
+            }).to_string();
+        }
+        if let Some(style) = output_style.bold {
+            result = self.re_bold.replace_all(&result, |caps: &regex::Captures| {
+                style.paint(&caps[1]).to_string()
+            }).to_string();
+        }
+        if let Some(style) = output_style.monospace {
+            result = self.re_monospace.replace_all(&result, |caps: &regex::Captures| {
+                // Extra newline at the start for monospace
+                format!("\n{}", style.paint(&caps[1]).to_string())
+            }).to_string();
+        }
 
-        return formatted_mono.to_string();
+        result
     }
 
-    // For visibility: turn spaces into dim "•" and newlines into dim "¶"
-    pub fn add_visibility(&self, text: &String, style: Style) -> String {
-        // Don't need to do nothing if --no-color is on
-        if !self.colour_mode {
-            return text.to_string();
-        }
-        
-        let text = Regex::new(r"[^ \n]+")
-            .unwrap()
-            .replace_all(&text, |caps: &regex::Captures| {
-                style.paint(&caps[0]).to_string()
-            });
-        let clear_text = Regex::new(r"\n")
-            .unwrap()
-            .replace_all(&text, Style::new().dimmed().paint("¶\n").to_string());
-        let clear_text = Regex::new(r" ")
-            .unwrap()
-            .replace_all(&clear_text, Style::new().dimmed().paint("•").to_string());
+    // For visibility: turn spaces into "•" and newlines into "¶"
+    pub fn show_whitespace(&self, text: &String, style: &Style, ws_style: &Option<Style>) -> String {
+        if let Some(ws_style) = ws_style {
+            let newl = format!("{}", ws_style.paint("¶\n"));
+            let space = format!("{}", ws_style.paint("•"));
 
-        return clear_text.to_string();
+            let re_nonwhitespace = Regex::new(r"[^\n ]+").unwrap();
+            re_nonwhitespace.replace_all(text, |caps: &regex::Captures| {
+                style.paint(&caps[0]).to_string()
+            }).to_string().replace('\n', &newl).replace(' ', &space)
+
+        } else {
+            style.paint(text).to_string()
+        }
     }
 }
 
@@ -106,43 +99,43 @@ mod tests {
 
     #[test]
     fn trim_spaces_with_format() {
-        let formatter = Formatter::new(true);
+        let formatter = Formatter::default();
         let text = "hello  world";
 
-        assert_eq!(formatter.format(text), "hello world");
+        assert_eq!(formatter.format(text, &OutputStyle::default()), "hello world");
     }
 
     #[test]
     fn does_not_trim_spaces_in_monospace() {
-        let formatter = Formatter::new(true);
+        let formatter = Formatter::default();
         let text = "`{\n    let x = 5;\n}`";
 
-        assert!(formatter.format(text).contains("{\n    let x = 5;\n}"));
+        assert!(formatter.format(text, &OutputStyle::default()).contains("{\n    let x = 5;\n}"));
     }
 
     #[test]
     fn format_monospace() {
-        let formatter = Formatter::new(true);
+        let formatter = Formatter::default();
         let text = "To create a new variable use `let x = 5`";
-        let formatted_text = formatter.format(text);
+        let formatted_text = formatter.format(text, &OutputStyle::default());
 
         assert!(!formatted_text.contains("`"));
     }
 
     #[test]
     fn format_monospace_adds_newline_if_there_is_none() {
-        let formatter = Formatter::new(true);
+        let formatter = Formatter::default();
         let text = "I have `no whitespace`";
-        let formatted_text = formatter.format(text);
+        let formatted_text = formatter.format(text, &OutputStyle::default());
 
         assert!(formatted_text.contains("\n"));
     }
 
     #[test]
     fn format_monospace_does_not_add_additional_newlines() {
-        let formatter = Formatter::new(true);
+        let formatter = Formatter::default();
         let text = "I have \n\n`lots of whitespace`";
-        let formatted_text = formatter.format(text);
+        let formatted_text = formatter.format(text, &OutputStyle::default());
 
         assert!(!formatted_text.contains("\n\n\n"));
     }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -106,7 +106,7 @@ mod tests {
 
     #[test]
     fn trim_spaces_with_format() {
-        let formatter = Formatter::new();
+        let formatter = Formatter::new(true);
         let text = "hello  world";
 
         assert_eq!(formatter.format(text), "hello world");
@@ -114,75 +114,15 @@ mod tests {
 
     #[test]
     fn does_not_trim_spaces_in_monospace() {
-        let formatter = Formatter::new();
+        let formatter = Formatter::new(true);
         let text = "`{\n    let x = 5;\n}`";
 
         assert!(formatter.format(text).contains("{\n    let x = 5;\n}"));
     }
 
     #[test]
-    fn format_bold_text() {
-        let formatter = Formatter::new();
-        let text = "Regular <<very bold>> text";
-        let formatted_text = formatter.format(text);
-
-        assert!(!formatted_text.contains("<<"));
-        assert!(formatted_text.contains(&formatter.fmt_bold));
-    }
-
-    #[test]
-    fn format_tricky_bold_text() {
-        let formatter = Formatter::new();
-        let text = "In life <<the trick is to realize that 2 > 3>>";
-        let formatted_text = formatter.format(text);
-
-        assert!(!formatted_text.contains("<<"));
-        assert!(formatted_text.contains(&formatter.fmt_bold));
-    }
-
-    #[test]
-    fn format_constants() {
-        let formatter = Formatter::new();
-        let text = "Some values {{never ever}} change";
-        let formatted_text = formatter.format(text);
-
-        assert!(!formatted_text.contains("{{"));
-        assert!(formatted_text.contains(&formatter.fmt_constant));
-    }
-
-    #[test]
-    fn format_tricky_constants() {
-        let formatter = Formatter::new();
-        let text = "When Santa smiles it looks like {{ :} }}";
-        let formatted_text = formatter.format(text);
-
-        assert!(!formatted_text.contains("{{"));
-        assert!(formatted_text.contains(&formatter.fmt_constant));
-    }
-
-    #[test]
-    fn format_variables() {
-        let formatter = Formatter::new();
-        let text = "The correct value of [[x]] is something you won't find";
-        let formatted_text = formatter.format(text);
-
-        assert!(!formatted_text.contains("[["));
-        assert!(formatted_text.contains(&formatter.fmt_variable));
-    }
-
-    #[test]
-    fn format_tricky_variables() {
-        let formatter = Formatter::new();
-        let text = "Vector item [[v[1]]] is nil if len is 1";
-        let formatted_text = formatter.format(text);
-
-        assert!(!formatted_text.contains("[["));
-        assert!(formatted_text.contains(&formatter.fmt_variable));
-    }
-
-    #[test]
     fn format_monospace() {
-        let formatter = Formatter::new();
+        let formatter = Formatter::new(true);
         let text = "To create a new variable use `let x = 5`";
         let formatted_text = formatter.format(text);
 
@@ -191,7 +131,7 @@ mod tests {
 
     #[test]
     fn format_monospace_adds_newline_if_there_is_none() {
-        let formatter = Formatter::new();
+        let formatter = Formatter::new(true);
         let text = "I have `no whitespace`";
         let formatted_text = formatter.format(text);
 
@@ -200,39 +140,11 @@ mod tests {
 
     #[test]
     fn format_monospace_does_not_add_additional_newlines() {
-        let formatter = Formatter::new();
+        let formatter = Formatter::new(true);
         let text = "I have \n\n`lots of whitespace`";
         let formatted_text = formatter.format(text);
 
         assert!(!formatted_text.contains("\n\n\n"));
-    }
-
-    #[test]
-    fn nest_variable_and_constant_in_bold() {
-        let formatter = Formatter::new();
-        let text = "Some things <<are {{bold}}, some others are [[extra]]>>";
-        let formatted_text = formatter.format(text);
-
-        assert!(!formatted_text.contains("<<"));
-        assert!(formatted_text.contains(&formatter.fmt_bold));
-        assert!(!formatted_text.contains("{{"));
-        assert!(formatted_text.contains(&formatter.fmt_constant));
-        assert!(!formatted_text.contains("[["));
-        assert!(formatted_text.contains(&formatter.fmt_variable));
-    }
-
-    #[test]
-    fn nest_constant_and_variable_in_monospace() {
-        let formatter = Formatter::new();
-        let text = "`[[status]] = {{EXCELLENT}}.freeze`";
-        let formatted_text = formatter.format(text);
-
-        assert!(!formatted_text.contains("{{"));
-        assert!(formatted_text.contains(&formatter.fmt_constant));
-        assert!(!formatted_text.contains("[["));
-        assert!(formatted_text.contains(&formatter.fmt_variable));
-
-        assert!(!formatted_text.contains("`"));
     }
 }
 

--- a/src/outputstyle.rs
+++ b/src/outputstyle.rs
@@ -1,0 +1,48 @@
+use ansi_term::{Color, Style};
+
+pub struct OutputStyle {
+    pub title: Style,
+    pub link: Style,
+    pub variable: Option<Style>,
+    pub constant: Option<Style>,
+    pub bold: Option<Style>,
+    pub monospace: Option<Style>,
+    pub input: Style,
+    pub input_whitespace: Option<Style>,
+    pub output: Style,
+    pub output_whitespace: Option<Style>,
+}
+
+impl OutputStyle {
+    pub fn plain() -> Self {
+        OutputStyle {
+            title: Style::default(),
+            link: Style::default(),
+            variable: Some(Style::default()),
+            constant: Some(Style::default()),
+            bold: Some(Style::default()),
+            monospace: Some(Style::default()),
+            input: Style::default(),
+            input_whitespace: None,
+            output: Style::default(),
+            output_whitespace: None,
+        }
+    }
+}
+
+impl Default for OutputStyle {
+    fn default() -> Self {
+        OutputStyle {
+            title: Style::new().fg(Color::Yellow).bold(),
+            link: Style::new().fg(Color::Yellow),
+            variable: Some(Style::new().fg(Color::Yellow)),
+            constant: Some(Style::new().fg(Color::Blue)),
+            bold: Some(Style::new().bold()),
+            monospace: Some(Style::default()),
+            input: Style::new().fg(Color::White),
+            input_whitespace: Some(Style::new().fg(Color::Black).dimmed()),
+            output: Style::new().fg(Color::Green),
+            output_whitespace: Some(Style::new().fg(Color::Black).dimmed()),
+        }
+    }
+}


### PR DESCRIPTION
- Rewrote most of the logic with https://crates.io/crates/ansi_term
- To not do a bunch of useless regex with --no-color on, we just exit the formatting functions now. I don't think it's noticeable performance-wise and it's cleaner to write.
- Now you can see espaces / newlines in the example
- Removed some @ricemath tests that are now useless since we use the crate.

I'm not too fond of the syntax for the colouring, maybe I missed a more idiomatic way to do it.
