### PR TITLE
added other 3 comparison methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,7 @@ dependencies = [
  "anyhow",
  "clap",
  "clap_complete",
+ "difference",
  "directories",
  "lazy_static",
  "rand",
@@ -243,6 +244,12 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "directories"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ reqwest = { version = "0.11.22", features = ["blocking"] }
 clap_complete = "4.4.3"
 ansi_term = "0.12"
 lazy_static = "1.4.0"
+difference = "2.0.0"


### PR DESCRIPTION
I rewrote https://github.com/Andriamanitra/clash/pull/18 because it became too messy. This way it should be easier for testing. I don't think I'll touch the dissimilar branch again, and I will delete it once the topic is sorted out.

I kept the three alternative functions for outputting the difference of `clash run`. The last two, using the difference crate are due to @ellnix.

I only adapted it to your previous refactoring, and also removed the abbreviation part of `zipped_difference`, that now returns a string.