### PR TITLE
Reverse

### DIFF
--- a/src/clash.rs
+++ b/src/clash.rs
@@ -114,14 +114,20 @@ impl Clash {
         format!("https://www.codingame.com/contribute/view/{}", self.public_handle)
     }
 
-    pub fn pretty_print(&self, ostyle: &OutputStyle) {
+    pub fn is_reverse_only(&self) -> bool {
+        let cdata: &ClashData = &self.last_version.data;
+        cdata.reverse && !cdata.fastest && !cdata.shortest
+    }
+
+    pub fn print_headers(&self, ostyle: &OutputStyle) {
+        let cdata: &ClashData = &self.last_version.data;
+        println!("{}\n", ostyle.title.paint(format!("=== {} ===", &cdata.title)));
+        println!("{}\n", ostyle.link.paint(self.codingame_link()));  
+    }
+
+    pub fn print_statement(&self, ostyle: &OutputStyle) {
         let cdata: &ClashData = &self.last_version.data;
 
-        // Title and link
-        println!("{}\n", ostyle.title.paint(format!("=== {} ===", &cdata.title)));
-        println!("{}\n", ostyle.link.paint(self.codingame_link()));
-
-        // Statement
         println!("{}\n", format_cg(&cdata.statement, ostyle));
         println!("{}\n{}\n", ostyle.title.paint("Input:"), format_cg(&cdata.input_description, ostyle));
         println!("{}\n{}\n", ostyle.title.paint("Output:"), format_cg(&cdata.output_description, ostyle));
@@ -129,7 +135,6 @@ impl Clash {
             println!("{}\n{}\n", ostyle.title.paint("Constraints:"), format_cg(constraints, ostyle));
         }
 
-        // Example testcase
         let example = self.testcases().first().expect("no test cases");
         println!("{}\n{}\n{}\n{}",
             ostyle.title.paint("Example:"),

--- a/src/clash.rs
+++ b/src/clash.rs
@@ -157,4 +157,11 @@ impl Clash {
             }
         }
     }
+
+    pub fn print_reverse_mode(&self, ostyle: &OutputStyle) {
+        self.print_headers(&ostyle);
+        println!("{}\n", ostyle.title.paint("REVERSE ONLY!"));
+        let selection = (0..self.testcases().len()).collect::<Vec<usize>>();
+        self.print_testcases(&ostyle, selection);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,6 +195,15 @@ impl App {
         }
         let clash: Clash = serde_json::from_str(&contents)?;
 
+        // If the clash is reverse only, print the headers and testcases.
+        if clash.is_reverse_only() {
+            clash.print_headers(&ostyle);
+            println!("REVERSE!\n");
+            let selection = (0..clash.testcases().len()).collect::<Vec<usize>>();
+            clash.print_testcases(&ostyle, selection);
+            return Ok(());
+        }
+
         // -t / --testcase flags (temporary)
         if let Some(values) = args.get_many::<usize>("testcases") {
             let testcases_to_print: Vec<usize> = values.cloned().collect();
@@ -215,7 +224,8 @@ impl App {
             return Ok(())
         }
 
-        clash.pretty_print(&ostyle);
+        clash.print_headers(&ostyle);
+        clash.print_statement(&ostyle);
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,15 +195,6 @@ impl App {
         }
         let clash: Clash = serde_json::from_str(&contents)?;
 
-        // If the clash is reverse only, print the headers and testcases.
-        if clash.is_reverse_only() {
-            clash.print_headers(&ostyle);
-            println!("REVERSE!\n");
-            let selection = (0..clash.testcases().len()).collect::<Vec<usize>>();
-            clash.print_testcases(&ostyle, selection);
-            return Ok(());
-        }
-
         // -t / --testcase flags (temporary)
         if let Some(values) = args.get_many::<usize>("testcases") {
             let testcases_to_print: Vec<usize> = values.cloned().collect();
@@ -222,6 +213,15 @@ impl App {
             };
             clash.print_testcases(&ostyle, selection);
             return Ok(())
+        }
+
+        // If the clash is reverse only, print the headers and testcases.
+        if clash.is_reverse_only() {
+            clash.print_headers(&ostyle);
+            println!("REVERSE!\n");
+            let selection = (0..clash.testcases().len()).collect::<Vec<usize>>();
+            clash.print_testcases(&ostyle, selection);
+            return Ok(());
         }
 
         clash.print_headers(&ostyle);

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,10 +217,7 @@ impl App {
 
         // If the clash is reverse only, print the headers and testcases.
         if clash.is_reverse_only() {
-            clash.print_headers(&ostyle);
-            println!("REVERSE!\n");
-            let selection = (0..clash.testcases().len()).collect::<Vec<usize>>();
-            clash.print_testcases(&ostyle, selection);
+            clash.print_reverse_mode(&ostyle);
             return Ok(());
         }
 


### PR DESCRIPTION
Now it only prints the headers (title, link) and the testcases when it is a reverse only.

Something more could be done to prevent long testcases from flooding the terminal (cf. `26547a34f8659808aa7db536d99b7c8ec57b5`).

