### PR TITLE
Add `clash testcase` command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -59,11 +59,6 @@ fn cli() -> clap::Command {
                         .default_missing_value("true")
                 )
                 .arg(arg!([PUBLIC_HANDLE] "hexadecimal handle of the clash"))
-                .arg(
-                    arg!(-'t' --"testcases" [TESTCASE_NUM] "show the inputs of the testset (shows all if no extra args)")
-                        .action(clap::ArgAction::Append)
-                        .value_parser(value_parser!(usize))
-                )
                 .arg(arg!(-'r' --"reverse" "print the clash in reverse mode"))
         )
         .subcommand(
@@ -225,26 +220,6 @@ impl App {
                 ostyle.input_whitespace = None;
                 ostyle.output_whitespace = None;
             }
-        }
-
-        // -t / --testcase flags (temporary)
-        if let Some(values) = args.get_many::<usize>("testcases") {
-            let testcases_to_print: Vec<usize> = values.cloned().collect();
-
-            // Return an error if any index is out of bounds
-            let max_idx = clash.testcases().len() / 2;
-            if testcases_to_print.iter().any(|&x| x > max_idx) {
-                return Err(anyhow!("Invalid index. The clash only has {} tests.", max_idx))
-            }
-
-            // If the flag has no arguments, print everything
-            let selection = if testcases_to_print.is_empty() {
-                (0..clash.testcases().len()).collect::<Vec<usize>>()
-            } else {
-                testcases_to_print
-            };
-            clash.print_testcases(&ostyle, selection);
-            return Ok(())
         }
 
         // --reverse flag

--- a/src/main.rs
+++ b/src/main.rs
@@ -421,9 +421,11 @@ impl App {
         for idx in testcase_indices {
             let testcase = match all_testcases.get((idx - 1) as usize) {
                 Some(x) => x,
-                None => return Err(anyhow!(
+                None => {
+                    return Err(anyhow!(
                     "Invalid testcase index {idx} (the current clash only has {num_testcases} test cases)"
-                )),
+                ))
+                }
             };
 
             if !(only_in || only_out) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,13 +333,12 @@ impl App {
 
         let all_testcases = self.read_clash(&handle)?.testcases().to_owned();
 
-        let testcases: Vec<&clash::TestCase> = if let Some(testcase_indices) = args.get_many::<u64>("testcases") {
-            testcase_indices.map(|idx| 
-                &all_testcases[(idx - 1) as usize]
-            ).collect()
-        } else {
-            all_testcases.iter().collect()
-        };
+        let testcases: Vec<&clash::TestCase> =
+            if let Some(testcase_indices) = args.get_many::<u64>("testcases") {
+                testcase_indices.map(|idx| &all_testcases[(idx - 1) as usize]).collect()
+            } else {
+                all_testcases.iter().collect()
+            };
 
         let num_tests = testcases.len();
         let suite_run = solution::run(testcases, run_command, timeout);

--- a/src/main.rs
+++ b/src/main.rs
@@ -423,23 +423,23 @@ impl App {
                 }
             }
 
-            let show_in = args.get_flag("in");
-            let show_out = args.get_flag("out");
+            let only_in = args.get_flag("in");
+            let only_out = args.get_flag("out");
 
             for idx in testcases_to_print {
                 let testcase = &clash.testcases()[(idx - 1) as usize];
-                if !show_in && !show_out {
+                if !(only_in || only_out) {
                     let styled_title = ostyle.title.paint(format!("#{} {}", idx, testcase.title));
                     println!("{styled_title}");
                     println!("{}", ostyle.secondary_title.paint("==== IN ====="));
                 }
-                if show_in || !show_out {
+                if !only_out {
                     println!("{}", testcase.styled_input(&ostyle));
                 }
-                if !show_in && !show_out {
+                if !(only_in || only_out) {
                     println!("{}", ostyle.secondary_title.paint("==== OUT ===="));
                 }
-                if show_out || !show_in {
+                if !only_in {
                     println!("{}", testcase.styled_output(&ostyle));
                 }
             }

--- a/src/solution.rs
+++ b/src/solution.rs
@@ -9,7 +9,7 @@ use suite_run::SuiteRun;
 use crate::clash::TestCase;
 mod test_run;
 
-pub fn run(testcases: Vec<TestCase>, run_command: Command, timeout: Duration) -> SuiteRun {
+pub fn run(testcases: Vec<&TestCase>, run_command: Command, timeout: Duration) -> SuiteRun {
     SuiteRun::new(testcases, run_command, timeout)
 }
 

--- a/src/solution/suite_run.rs
+++ b/src/solution/suite_run.rs
@@ -7,14 +7,14 @@ use wait_timeout::ChildExt;
 use super::test_run::{TestRun, TestRunResult};
 use crate::clash::TestCase;
 
-pub struct SuiteRun {
-    testcases: IntoIter<TestCase>,
+pub struct SuiteRun<'a> {
+    testcases: IntoIter<&'a TestCase>,
     run_command: Command,
     timeout: Duration,
 }
 
-impl Iterator for SuiteRun {
-    type Item = TestRun;
+impl<'a> Iterator for SuiteRun<'a> {
+    type Item = TestRun<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let test = match self.testcases.next() {
@@ -27,8 +27,8 @@ impl Iterator for SuiteRun {
     }
 }
 
-impl SuiteRun {
-    pub fn new(testcases: Vec<TestCase>, run_command: Command, timeout: Duration) -> Self {
+impl<'a> SuiteRun<'a> {
+    pub fn new(testcases: Vec<&'a TestCase>, run_command: Command, timeout: Duration) -> Self {
         Self {
             testcases: testcases.into_iter(),
             run_command,
@@ -36,7 +36,7 @@ impl SuiteRun {
         }
     }
 
-    fn run_testcase(&mut self, test: TestCase) -> TestRun {
+    fn run_testcase(&mut self, test: &'a TestCase) -> TestRun<'a> {
         let mut run = self
             .run_command
             .stdin(std::process::Stdio::piped())

--- a/src/solution/test_run.rs
+++ b/src/solution/test_run.rs
@@ -11,13 +11,13 @@ pub enum TestRunResult {
 }
 
 #[derive(Clone)]
-pub struct TestRun {
-    testcase: TestCase,
+pub struct TestRun<'a> {
+    testcase: &'a TestCase,
     result: TestRunResult,
 }
 
-impl TestRun {
-    pub fn new(testcase: TestCase, result: TestRunResult) -> Self {
+impl<'a> TestRun<'a> {
+    pub fn new(testcase: &'a TestCase, result: TestRunResult) -> Self {
         Self { testcase, result }
     }
 


### PR DESCRIPTION
Add a command `clash testcase` that can be used like this:

```
clash testcase 1,2,3  # print titles, inputs and outputs of test 1, validator 1, and test 2
clash testcase --in 3  # print just the input of test 2
clash testcase --out 1  # print just the expected output of test 1
```

The command should also respect --show-whitespace and --no-color options.

I also added `--testcases` parameter to `clash run` so you can pick which tests to run.

closes #9 