### PR TITLE
Lib crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "clash"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+name = "clashlib"
+path = "src/lib.rs"
+
 [dependencies]
 clap = { version = "4.4.6", features = ["derive", "cargo"] }
 directories = "5.0"

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -239,7 +239,7 @@ pub fn show_whitespace(text: &str, style: &Style, ws_style: &Style) -> String {
 /// Construct a new style that is the combination of `inner` and `outer` style.
 /// The new style keeps all attributes from `inner` and adds ones from `outer`
 /// if the corresponding attribute in `inner` is the default for that attribute.
-pub fn nested_style(inner: &Style, outer: &Style) -> Style {
+fn nested_style(inner: &Style, outer: &Style) -> Style {
     Style {
         foreground: inner.foreground.or(outer.foreground),
         background: inner.background.or(outer.background),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod clash;
-pub mod formatter;
+mod formatter;
 pub mod outputstyle;
 pub mod solution;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod clash;
+pub mod formatter;
+pub mod outputstyle;
+pub mod solution;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,16 +4,11 @@ use std::str::FromStr;
 
 use anyhow::{anyhow, Context, Result};
 use clap::ArgMatches;
+use clashlib::clash::{Clash, TestCase};
+use clashlib::outputstyle::OutputStyle;
+use clashlib::solution;
 use directories::ProjectDirs;
 use rand::seq::IteratorRandom;
-
-pub mod clash;
-pub mod formatter;
-pub mod outputstyle;
-pub mod solution;
-
-use clash::Clash;
-use outputstyle::OutputStyle;
 
 #[derive(Clone)]
 pub enum OutputStyleOption {
@@ -353,12 +348,11 @@ impl App {
 
         let all_testcases = self.read_clash(&handle)?.testcases().to_owned();
 
-        let testcases: Vec<&clash::TestCase> =
-            if let Some(testcase_indices) = args.get_many::<u64>("testcases") {
-                testcase_indices.map(|idx| &all_testcases[(idx - 1) as usize]).collect()
-            } else {
-                all_testcases.iter().collect()
-            };
+        let testcases: Vec<&TestCase> = if let Some(testcase_indices) = args.get_many::<u64>("testcases") {
+            testcase_indices.map(|idx| &all_testcases[(idx - 1) as usize]).collect()
+        } else {
+            all_testcases.iter().collect()
+        };
 
         let num_tests = testcases.len();
         let suite_run = solution::run(testcases, run_command, timeout);

--- a/src/solution/test_run.rs
+++ b/src/solution/test_run.rs
@@ -63,7 +63,7 @@ impl<'a> TestRun<'a> {
     }
 }
 
-pub fn print_failure(testcase: &TestCase, stdout: &str, stderr: &str, ostyle: &OutputStyle) {
+fn print_failure(testcase: &TestCase, stdout: &str, stderr: &str, ostyle: &OutputStyle) {
     println!(
         "{}\n{}\n{}\n{}",
         ostyle.secondary_title.paint("===== INPUT ======"),
@@ -85,7 +85,7 @@ pub fn print_failure(testcase: &TestCase, stdout: &str, stderr: &str, ostyle: &O
 }
 
 // https://stackoverflow.com/a/40457615/5465108
-pub struct LinesWithEndings<'a> {
+struct LinesWithEndings<'a> {
     input: &'a str,
 }
 
@@ -110,7 +110,7 @@ impl<'a> Iterator for LinesWithEndings<'a> {
     }
 }
 
-pub fn print_diff(testcase: &TestCase, stdout: &str, ostyle: &OutputStyle) {
+fn print_diff(testcase: &TestCase, stdout: &str, ostyle: &OutputStyle) {
     use dissimilar::Chunk::*;
     use itertools::EitherOrBoth::{Both, Left, Right};
     use itertools::Itertools;


### PR DESCRIPTION
This PR is an attempt at moving most of the logic to a separate lib crate. Using a lib crate will allow us to use doc tests and expose some of our backend logic for other projects to use. 

It would probably be a good idea to re-think some of the APIs that we want to expose if the goal is to make this into a library that others can rely on. There's lots of potentially useful logic in `main.rs` (which is part of the bin crate rather than the lib crate).