### PR TITLE
create the clash folder if it doesn't exist already

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.vscode

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,6 +196,7 @@ impl App {
         }
     }
 
+    // This may fail the very first time we call `show` if `next` was never run.
     fn current_handle(&self) -> Result<PublicHandle> {
         let content = std::fs::read_to_string(&self.current_clash_file)
             .with_context(|| format!("Unable to read {:?}", &self.current_clash_file))?;
@@ -384,7 +385,9 @@ impl App {
 
     fn fetch(&self, args: &ArgMatches) -> Result<()> {
         std::fs::create_dir_all(&self.clash_dir)?;
-        let handles = args.get_many::<PublicHandle>("PUBLIC_HANDLE").context("Should have many handles")?;
+        let handles = args
+            .get_many::<PublicHandle>("PUBLIC_HANDLE")
+            .with_context(|| format!("Should have many handles"))?;
         for handle in handles {
             let http = reqwest::blocking::Client::new();
             let res = http

--- a/src/main.rs
+++ b/src/main.rs
@@ -383,23 +383,21 @@ impl App {
     }
 
     fn fetch(&self, args: &ArgMatches) -> Result<()> {
-        if let Some(handles) = args.get_many::<PublicHandle>("PUBLIC_HANDLE") {
-            for handle in handles {
-                let http = reqwest::blocking::Client::new();
-                let res = http
-                    .post("https://www.codingame.com/services/Contribution/findContribution")
-                    .body(format!(r#"["{}", true]"#, handle))
-                    .header(reqwest::header::CONTENT_TYPE, "application/json")
-                    .send()?;
-                let content = res.error_for_status()?.text()?;
-                let clash_file_path = self.clash_dir.join(format!("{}.json", handle));
-                std::fs::write(&clash_file_path, &content)?;
-                println!("Saved clash {} as {}", &handle, &clash_file_path.display());
-            }
-            Ok(())
-        } else {
-            Err(anyhow!("fetched no clashes"))
+        std::fs::create_dir_all(&self.clash_dir)?;
+        let handles = args.get_many::<PublicHandle>("PUBLIC_HANDLE").context("Should have many handles")?;
+        for handle in handles {
+            let http = reqwest::blocking::Client::new();
+            let res = http
+                .post("https://www.codingame.com/services/Contribution/findContribution")
+                .body(format!(r#"["{}", true]"#, handle))
+                .header(reqwest::header::CONTENT_TYPE, "application/json")
+                .send()?;
+            let content = res.error_for_status()?.text()?;
+            let clash_file_path = self.clash_dir.join(format!("{}.json", handle));
+            std::fs::write(&clash_file_path, &content)?;
+            println!("Saved clash {} as {}", &handle, &clash_file_path.display());
         }
+        Ok(())
     }
 
     fn showtests(&self, args: &ArgMatches) -> Result<()> {


### PR DESCRIPTION
And some simplified logic in `main::fetch`, noticing that `clap::get_many` is infallible at that point due to how our PublicHandle parser works.