### PR TITLE
stubgen changes

### DIFF
--- a/config/stub_templates/cpp/read_many.cpp.jinja
+++ b/config/stub_templates/cpp/read_many.cpp.jinja
@@ -1,5 +1,5 @@
 {%- for var in vars %}
-{%- if var.input_comment -%}# {{ var.ident }}: {{ var.input_comment }}
+{%- if var.input_comment -%}// {{ var.ident }}: {{ var.input_comment }}
 {% endif -%}
 {% endfor -%}
 

--- a/config/stub_templates/cpp/stub_config.toml
+++ b/config/stub_templates/cpp/stub_config.toml
@@ -16,8 +16,8 @@ keywords = [
   "auto", "break", "case", "char",
   "const", "continue", "default", "do",
   "double", "else", "enum", "extern",
-  "float", "for", "goto", "if",
-  "int", "long", "register", "return",
+  "float", "for", "goto", "if", "int",
+  "long", "operator", "register", "return",
   "short", "signed", "sizeof", "static",
   "struct", "switch", "typedef", "union",
   "unsigned", "void", "volatile", "while"

--- a/config/stub_templates/cpp/stub_config.toml
+++ b/config/stub_templates/cpp/stub_config.toml
@@ -17,8 +17,8 @@ keywords = [
   "const", "continue", "default", "do",
   "double", "else", "enum", "extern",
   "float", "for", "goto", "if", "int",
-  "long", "operator", "register", "return",
-  "short", "signed", "sizeof", "static",
-  "struct", "switch", "typedef", "union",
+  "long", "new", "operator", "register", "return",
+  "short", "signed", "sizeof", "static", "string",
+  "struct", "switch", "template", "typedef", "union",
   "unsigned", "void", "volatile", "while"
 ]

--- a/config/stub_templates/cpp/write_join.cpp.jinja
+++ b/config/stub_templates/cpp/write_join.cpp.jinja
@@ -10,6 +10,6 @@
   {%- endif -%}
 {%- endfor -%}
 
-{%- for line in output_comments -%} # {{ line }}
+{%- for line in output_comments -%} // {{ line }}
 {% endfor -%}
 cout << {{ out | replace(from='" << "', to="") }} << endl;

--- a/src/main.rs
+++ b/src/main.rs
@@ -495,15 +495,12 @@ impl App {
         let config = self.build_stub_config(args)?;
 
         let stub_generator = match args.get_one::<PathBuf>("from-file") {
-            Some(fname) => {
-                if fname.to_str() == Some("-") {
-                    let mut input = String::new();
-                    std::io::Read::read_to_string(&mut std::io::stdin(), &mut input)?;
-                    input
-                } else {
-                    std::fs::read_to_string(fname)?
-                }
+            Some(fname) if fname.to_str() == Some("-") => {
+                let mut input = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut input)?;
+                input
             }
+            Some(fname) => std::fs::read_to_string(fname)?,
             None if args.get_flag("from-reference") => {
                 let reference_stub = indoc! {r##"
                     read anInt:int

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::io::Read;
 use std::path::PathBuf;
 use std::process::Command;
 use std::str::FromStr;
@@ -497,7 +498,7 @@ impl App {
         let stub_generator = match args.get_one::<PathBuf>("from-file") {
             Some(fname) if fname.to_str() == Some("-") => {
                 let mut input = String::new();
-                std::io::Read::read_to_string(&mut std::io::stdin(), &mut input)?;
+                std::io::stdin().read_to_string(&mut input)?;
                 input
             }
             Some(fname) => std::fs::read_to_string(fname)?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,10 +155,10 @@ fn cli() -> clap::Command {
                 .about("Generate input handling code for a given language")
                 .arg(arg!(<PROGRAMMING_LANGUAGE> "Programming language of the solution stub"))
                 .arg(
-                    arg!(--"from-file" <STUBFILE> "Generate stub from stubgen file instead of the current clash")
+                    arg!(--"from-file" <STUBFILE> "Generate stub from a stub generator file instead of the current clash")
                         .value_parser(clap::value_parser!(PathBuf))
                 )
-                .arg(arg!(--"from-reference" "Generate stub from a reference stub generator instead of the current clash").conflicts_with("from-file"))
+                .arg(arg!(--"from-reference" "Generate stub from the reference stub generator instead of the current clash").conflicts_with("from-file"))
                 .after_help(
                     "Prints boilerplate code for the input of the current clash.\
                     \nIntended to be piped to a file.\

--- a/src/main.rs
+++ b/src/main.rs
@@ -502,7 +502,7 @@ impl App {
             }
             Some(fname) => std::fs::read_to_string(fname)?,
             None if args.get_flag("from-reference") => {
-                let reference_stub = indoc! {r##"
+                const REFERENCE_STUB: &str = indoc! {r##"
                     read anInt:int
                     read aFloat:float
                     read Long:long
@@ -532,7 +532,7 @@ impl App {
                     INPUT
                     anInt: An input comment over anInt
                 "##};
-                reference_stub.to_owned()
+                REFERENCE_STUB.to_owned()
             }
             None => {
                 let handle = self.current_handle()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,7 +412,7 @@ impl App {
         std::fs::create_dir_all(&self.clash_dir)?;
         let handles = args
             .get_many::<PublicHandle>("PUBLIC_HANDLE")
-            .with_context(|| format!("Should have many handles"))?;
+            .with_context(|| "Should have many handles")?;
         for handle in handles {
             let http = reqwest::blocking::Client::new();
             let res = http

--- a/src/stub/language/variable_name_options.rs
+++ b/src/stub/language/variable_name_options.rs
@@ -65,8 +65,8 @@ impl VariableNameOptions {
     fn convert(&self, variable_name: &str) -> String {
         match self.casing {
             Casing::SnakeCase => Self::convert_to_snake_case(variable_name),
-            Casing::PascalCase => Self::covert_to_pascal_case(variable_name),
-            Casing::CamelCase => Self::covert_to_camel_case(variable_name),
+            Casing::PascalCase => Self::convert_to_pascal_case(variable_name),
+            Casing::CamelCase => Self::convert_to_camel_case(variable_name),
         }
     }
 
@@ -76,14 +76,13 @@ impl VariableNameOptions {
                 format!("{}_{}", &caps[1], &caps[2].to_lowercase())
             })
             .to_lowercase()
-            .to_string()
     }
 
-    fn covert_to_pascal_case(variable_name: &str) -> String {
+    fn convert_to_pascal_case(variable_name: &str) -> String {
         variable_name[0..1].to_uppercase() + &Self::pascalize(&variable_name[1..])
     }
 
-    fn covert_to_camel_case(variable_name: &str) -> String {
+    fn convert_to_camel_case(variable_name: &str) -> String {
         variable_name[0..1].to_lowercase() + &Self::pascalize(&variable_name[1..])
     }
 

--- a/src/stub/language/variable_name_options.rs
+++ b/src/stub/language/variable_name_options.rs
@@ -50,7 +50,7 @@ impl VariableNameOptions {
             ident: self.transform_variable_name(&var.ident),
             var_type: var.var_type,
             input_comment: var.input_comment.clone(),
-            max_length: var.max_length.clone(),
+            max_length: var.max_length.as_ref().map(|s| self.transform_variable_name(s)).to_owned(),
         }
     }
 

--- a/src/stub/language/variable_name_options.rs
+++ b/src/stub/language/variable_name_options.rs
@@ -48,7 +48,7 @@ impl VariableNameOptions {
     pub fn transform_variable_command(&self, var: &VariableCommand) -> VariableCommand {
         VariableCommand {
             ident: self.transform_variable_name(&var.ident),
-            var_type: var.var_type.clone(),
+            var_type: var.var_type,
             input_comment: var.input_comment.clone(),
             max_length: var.max_length.clone(),
         }

--- a/src/stub/parser.rs
+++ b/src/stub/parser.rs
@@ -224,7 +224,7 @@ impl<'a> Parser<'a> {
             | Cmd::WriteJoin {
                 ref mut output_comment,
                 ..
-            } if output_comment.is_empty() => *output_comment = new_comment.clone(),
+            } if output_comment.is_empty() => output_comment.clone_from(new_comment),
             Cmd::Loop { ref mut command, .. } => {
                 Self::update_cmd_with_output_comment(command, new_comment);
             }
@@ -271,12 +271,7 @@ impl<'a> Parser<'a> {
     }
 
     fn first_non_whitespace_token(&mut self) -> Option<&'a str> {
-        while let Some(token) = self.token_stream.next() {
-            if token != "\n" && token != "" {
-                return Some(token);
-            }
-        }
-        None
+        self.token_stream.by_ref().find(|&token| token != "\n" && !token.is_empty())
     }
 
     fn rest_of_line(&mut self) -> Option<String> {


### PR DESCRIPTION
* Apply suggestions from `cargo clippy` to simplify code in places
* Fix input comment in C++ read_many
* Introduce --from-reference and --from-file args to `generate-stub`:
```console
$ clash generate-stub rust --from-reference  # renamed from --debug
$ echo 'read a:int' | clash generate-stub rust --from-file -
$ clash generate-stub rust --from-file my.stubgen
```