### PR TITLE
Refactor updating of var_type for JoinTerms

### DIFF
--- a/config/stub_templates/cpp/write_join.cpp.jinja
+++ b/config/stub_templates/cpp/write_join.cpp.jinja
@@ -1,6 +1,6 @@
 {%- set_global out = "" -%}
 {%- for term in terms -%}
-  {%- if term.is_variable -%}
+  {%- if term.var_type -%}
     {%- set_global out = out ~ term.ident -%}
   {%- else -%}
     {%- set_global out = out ~ '"' ~ term.ident ~ '"' -%}

--- a/config/stub_templates/python/write_join.py.jinja
+++ b/config/stub_templates/python/write_join.py.jinja
@@ -1,11 +1,9 @@
 {%- set_global out = "" -%}
 {%- for term in terms -%}
-  {%- if term.var_type -%}
-    {%- if term.var_type == "String" or term.var_type == "Word" -%}
-      {%- set_global out = out ~ term.ident -%}
-    {%- else -%}
-      {%- set_global out = out ~ "str(" ~ term.ident ~ ")" -%}
-    {%- endif -%}
+  {%- if term.var_type == "String" or term.var_type == "Word" -%}
+    {%- set_global out = out ~ term.ident -%}
+  {%- elif term.var_type -%}
+    {%- set_global out = out ~ "str(" ~ term.ident ~ ")" -%}
   {%- else -%}
     {%- set_global out = out ~ '"' ~ term.ident ~ '"' -%}
   {%- endif -%}

--- a/config/stub_templates/python/write_join.py.jinja
+++ b/config/stub_templates/python/write_join.py.jinja
@@ -1,6 +1,6 @@
 {%- set_global out = "" -%}
 {%- for term in terms -%}
-  {%- if term.is_variable -%}
+  {%- if term.var_type -%}
     {%- if term.var_type == "String" or term.var_type == "Word" -%}
       {%- set_global out = out ~ term.ident -%}
     {%- else -%}

--- a/config/stub_templates/ruby/write_join.rb.jinja
+++ b/config/stub_templates/ruby/write_join.rb.jinja
@@ -1,6 +1,6 @@
 puts "
 {%- for term in terms -%}
-  {%- if term.is_variable -%}
+  {%- if term.var_type -%}
     {{- '#{' }}{{ term.ident }}{{ '}' -}}
   {%- else -%}
     {{- term.ident -}}

--- a/src/stub.rs
+++ b/src/stub.rs
@@ -89,25 +89,12 @@ impl VariableCommand {
 #[derive(Serialize, Clone, Debug)]
 pub struct JoinTerm {
     pub ident: String,
-    pub is_variable: bool,
     pub var_type: Option<VarType>,
 }
 
 impl JoinTerm {
-    pub fn new_literal(ident: String) -> Self {
-        Self {
-            ident,
-            is_variable: false,
-            var_type: None,
-        }
-    }
-
-    pub fn new_variable(ident: String) -> Self {
-        Self {
-            ident,
-            is_variable: true,
-            var_type: None,
-        }
+    pub fn new(ident: String, var_type: Option<VarType>) -> JoinTerm {
+        JoinTerm { ident, var_type }
     }
 }
 

--- a/src/stub/parser.rs
+++ b/src/stub/parser.rs
@@ -107,16 +107,12 @@ impl<'a> Parser<'a> {
             .split(',')
             .map(|term| {
                 if term.contains('"') {
-                    let term_name = term.trim_matches(|c| c != '"').trim_matches('"').to_string();
-                    JoinTerm::new_literal(term_name)
+                    let ident = term.trim_matches(|c| c != '"').trim_matches('"').to_string();
+                    JoinTerm::new(ident, None)
                 } else {
                     let ident = term.trim().to_string();
                     match self.read_pairings.get(&ident) {
-                        Some(var_type) => JoinTerm {
-                            ident,
-                            is_variable: true,
-                            var_type: Some(*var_type),
-                        },
+                        Some(var_type) => JoinTerm::new(ident, Some(*var_type)),
                         None => panic!("The JoinTerm '{}' was not previously initialized.", &ident),
                     }
                 }

--- a/src/stub/parser.rs
+++ b/src/stub/parser.rs
@@ -14,6 +14,7 @@ pub fn parse_generator_stub(generator: &str) -> Result<Stub> {
 /// Exists solely to be consumed with `.parse()`
 struct Parser<'a> {
     token_stream: Box<dyn Iterator<Item = &'a str> + 'a>,
+    pub read_pairings: std::collections::BTreeMap<String, VarType>,
 }
 
 impl<'a> Parser<'a> {
@@ -26,6 +27,7 @@ impl<'a> Parser<'a> {
         let token_stream = stub.lines().flat_map(|line| line.split(' ').chain(iter::once("\n")));
         Self {
             token_stream: Box::new(token_stream),
+            read_pairings: std::collections::BTreeMap::new(),
         }
     }
 
@@ -46,25 +48,6 @@ impl<'a> Parser<'a> {
                 "\n" | ""   => continue,
                 thing => panic!("Unknown token stub generator: '{}'", thing),
             };
-        }
-
-        // Update WriteJoin terms with their respective var_type.
-        let mut read_pairings = std::collections::BTreeMap::new();
-        for read_cmd in &stub.commands {
-            if let Cmd::Read(var_cmds) = read_cmd {
-                for var_cmd in var_cmds {
-                    read_pairings.insert(var_cmd.ident.clone(), var_cmd.var_type);
-                }
-            }
-        }
-        for cmd in &mut stub.commands {
-            if let Cmd::WriteJoin { join_terms, output_comment: _ } = cmd {
-                for term in join_terms.iter_mut() {
-                    if let Some(var_type) = read_pairings.get(&term.ident) {
-                        term.var_type = Some(*var_type);
-                    }
-                }
-            }
         }
 
         Ok(stub)
@@ -127,7 +110,15 @@ impl<'a> Parser<'a> {
                     let term_name = term.trim_matches(|c| c != '"').trim_matches('"').to_string();
                     JoinTerm::new_literal(term_name)
                 } else {
-                    JoinTerm::new_variable(term.trim().to_string())
+                    let ident = term.trim().to_string();
+                    match self.read_pairings.get(&ident) {
+                        Some(var_type) => JoinTerm {
+                            ident,
+                            is_variable: true,
+                            var_type: Some(*var_type),
+                        },
+                        None => panic!("The JoinTerm '{}' was not previously initialized.", &ident),
+                    }
                 }
             })
             .collect();
@@ -174,10 +165,10 @@ impl<'a> Parser<'a> {
             panic!("Empty line after read keyword")
         };
 
-        tokens.into_iter().filter_map(Self::parse_variable).collect()
+        tokens.into_iter().filter_map(|token| self.parse_variable(token)).collect()
     }
 
-    fn parse_variable(token: &str) -> Option<VariableCommand> {
+    fn parse_variable(&mut self, token: &str) -> Option<VariableCommand> {
         // A token may be empty if extra spaces were present: "read   x:int  "
         if token.is_empty() {
             return None
@@ -186,6 +177,7 @@ impl<'a> Parser<'a> {
             panic!("Variable must have type")
         };
         let (var_type, max_length) = Self::extract_type_and_length(type_string);
+        self.read_pairings.insert(String::from(ident), var_type);
 
         Some(VariableCommand::new(ident.to_string(), var_type, max_length))
     }

--- a/src/stub/parser.rs
+++ b/src/stub/parser.rs
@@ -14,7 +14,7 @@ pub fn parse_generator_stub(generator: &str) -> Result<Stub> {
 /// Exists solely to be consumed with `.parse()`
 struct Parser<'a> {
     token_stream: Box<dyn Iterator<Item = &'a str> + 'a>,
-    pub read_pairings: std::collections::BTreeMap<String, VarType>,
+    read_pairings: std::collections::BTreeMap<String, VarType>,
 }
 
 impl<'a> Parser<'a> {

--- a/src/stub/parser/parser_tests.rs
+++ b/src/stub/parser/parser_tests.rs
@@ -57,6 +57,12 @@ fn parse_write_captures_lines_of_text_until_empty_line() {
 }
 
 #[test]
+#[should_panic]
+fn parse_write_errors_on_write_join_with_undeclared_vars() {
+    Parser::new("join(\"hello\", world)").parse_write();
+}
+
+#[test]
 fn parse_write_returns_write_joins() {
     let mut parser = Parser::new("join(\"hello\", world)");
     parser.read_pairings.insert(String::from("world"), VarType::Bool);

--- a/src/stub/parser/parser_tests.rs
+++ b/src/stub/parser/parser_tests.rs
@@ -59,6 +59,7 @@ fn parse_write_captures_lines_of_text_until_empty_line() {
 #[test]
 fn parse_write_returns_write_joins() {
     let mut parser = Parser::new("join(\"hello\", world)");
+    parser.read_pairings.insert(String::from("world"), VarType::Bool);
     let Cmd::WriteJoin { join_terms, .. } = parser.parse_write() else { panic!() };
 
     let [

--- a/src/stub/parser/parser_tests.rs
+++ b/src/stub/parser/parser_tests.rs
@@ -58,9 +58,13 @@ fn parse_write_captures_lines_of_text_until_empty_line() {
 
 #[test]
 fn parse_write_returns_write_joins() {
-    let mut parser = Parser::new("join(\"hello\", world)");
-    parser.read_pairings.insert(String::from("world"), VarType::Bool);
-    let Cmd::WriteJoin { join_terms, .. } = parser.parse_write() else { panic!() };
+    let mut parser = Parser::new(indoc! {r##"
+        world:int
+        join("hello", world)
+    "##});
+
+    parser.parse_read();
+    let Cmd::WriteJoin { join_terms, output_comment: _} = parser.parse_write() else { panic!() };
 
     let [
         JoinTerm { ident: first_term,  .. }, 

--- a/src/stub/renderer.rs
+++ b/src/stub/renderer.rs
@@ -96,7 +96,7 @@ impl Renderer {
             .iter()
             .cloned()
             .map(|mut term| {
-                if term.is_variable {
+                if term.var_type.is_some() {
                     term.ident = self.lang.variable_name_options.transform_variable_name(&term.ident);
                 }
                 term


### PR DESCRIPTION
Trying to make the updating of JoinTerms a bit more reasonable. The goal is to eventually get rid of `is_variable`.

I had to make `read_pairings` pub to deal with a test that (rightfully) crashes now (another option would be to remove the test).