### PR TITLE
Support S-Expression syntax in stubs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,7 @@ dependencies = [
  "clap_complete",
  "directories",
  "dissimilar",
+ "dyn-clone",
  "include_dir",
  "indoc",
  "itertools",
@@ -402,6 +403,12 @@ name = "dissimilar"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "440d59c0c6d96354061909b4769b2ca03868dbaee203e7b779d9021ebbde3058"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "either"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,4 @@ wait-timeout = "0.2.0"
 toml = "0.8.12"
 tera = "1.19.1"
 include_dir = { version = "0.7.3", features = ["glob"]}
+dyn-clone = "1.0.17"

--- a/src/stub.rs
+++ b/src/stub.rs
@@ -2,12 +2,15 @@ pub mod language;
 mod parser;
 mod renderer;
 pub mod stub_config;
+pub mod preprocessor;
 
 use anyhow::Result;
 use indoc::indoc;
 pub use language::Language;
 use serde::Serialize;
 pub use stub_config::StubConfig;
+
+use preprocessor::RenderableCmd;
 
 pub fn generate(config: StubConfig, generator: &str) -> Result<String> {
     let stub = parser::parse_generator_stub(generator)?;
@@ -98,7 +101,7 @@ impl JoinTerm {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone)]
 pub enum Cmd {
     Read(Vec<VariableCommand>),
     Loop {
@@ -117,6 +120,7 @@ pub enum Cmd {
         join_terms: Vec<JoinTerm>,
         output_comment: Vec<String>,
     },
+    External(Box<dyn RenderableCmd>),
 }
 
 pub const SIMPLE_REFERENCE_STUB: &str = indoc! {r##"

--- a/src/stub.rs
+++ b/src/stub.rs
@@ -14,8 +14,8 @@ pub use stub_config::StubConfig;
 pub fn generate(config: StubConfig, generator: &str) -> Result<String> {
     let mut stub = parser::parse_generator_stub(generator)?;
 
-    for processor in config.language.preprocessors.iter() {
-        processor(&mut stub);
+    if let Some(processor) = config.language.preprocessor {
+        processor(&mut stub)
     }
 
     // eprint!("=======\n{:?}\n======\n", generator);

--- a/src/stub/language.rs
+++ b/src/stub/language.rs
@@ -33,7 +33,7 @@ where
 {
     let preprocessor: String = Deserialize::deserialize(deserializer)?;
     match preprocessor.as_str() {
-        "s-expression" => Ok(Some(preprocessor::s_expressions::transform)),
+        "lisp-like" => Ok(Some(preprocessor::lisp_like::transform)),
         _ => Err(D::Error::custom(format!("preprocessor {preprocessor} not found."))),
     }
 }

--- a/src/stub/language.rs
+++ b/src/stub/language.rs
@@ -23,22 +23,17 @@ pub struct Language {
     pub variable_name_options: VariableNameOptions,
     pub source_file_ext: String,
     pub type_tokens: TypeTokens,
-    #[serde(deserialize_with = "deser_preprocessors", default)]
-    pub preprocessors: Vec<Preprocessor>,
+    #[serde(deserialize_with = "deser_preprocessor", default)]
+    pub preprocessor: Option<Preprocessor>,
 }
 
-fn deser_preprocessors<'de, D>(deserializer: D) -> Result<Vec<Preprocessor>, D::Error>
+fn deser_preprocessor<'de, D>(deserializer: D) -> Result<Option<Preprocessor>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    let preprocessors: Vec<String> = Deserialize::deserialize(deserializer)?;
-    let mut output: Vec<Preprocessor> = Vec::new();
-
-    for preprocessor_name in preprocessors {
-        match preprocessor_name.as_str() {
-            "s-expression" => output.push(preprocessor::s_expressions::transform),
-            _ => return Err(D::Error::custom(format!("preprocessor {preprocessor_name} not found."))),
-        }
+    let preprocessor: String = Deserialize::deserialize(deserializer)?;
+    match preprocessor.as_str() {
+        "s-expression" => Ok(Some(preprocessor::s_expressions::transform)),
+        _ => Err(D::Error::custom(format!("preprocessor {preprocessor} not found."))),
     }
-    Ok(output)
 }

--- a/src/stub/language.rs
+++ b/src/stub/language.rs
@@ -1,7 +1,10 @@
+use serde::de::Error;
 use serde::{Deserialize, Serialize};
 
 mod variable_name_options;
 use variable_name_options::VariableNameOptions;
+
+use super::preprocessor::{self, Preprocessor};
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "PascalCase")]
@@ -14,10 +17,28 @@ pub struct TypeTokens {
     pub string: Option<String>,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Clone, Debug)]
 pub struct Language {
     pub name: String,
     pub variable_name_options: VariableNameOptions,
     pub source_file_ext: String,
     pub type_tokens: TypeTokens,
+    #[serde(deserialize_with = "deser_preprocessors", default)]
+    pub preprocessors: Vec<Preprocessor>,
+}
+
+fn deser_preprocessors<'de, D>(deserializer: D) -> Result<Vec<Preprocessor>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let preprocessors: Vec<String> = Deserialize::deserialize(deserializer)?;
+    let mut output: Vec<Preprocessor> = Vec::new();
+
+    for preprocessor_name in preprocessors {
+        match preprocessor_name.as_str() {
+            "s-expression" => output.push(preprocessor::s_expressions::transform),
+            _ => return Err(D::Error::custom(format!("preprocessor {preprocessor_name} not found."))),
+        }
+    }
+    Ok(output)
 }

--- a/src/stub/preprocessor.rs
+++ b/src/stub/preprocessor.rs
@@ -1,0 +1,32 @@
+use super::{renderer::Renderer, Stub};
+
+pub trait RenderableCmd: Renderable + std::fmt::Debug + DynClone {}
+
+pub trait Renderable {
+    fn render(&self, renderer: &Renderer) -> String;
+}
+
+pub trait Preprocessor {
+    fn transform(stub: &mut Stub);
+}
+
+// Workaround for trait object to implement Clone:
+// https://users.rust-lang.org/t/how-to-deal-with-the-trait-cannot-be-made-into-an-object-error-in-rust-which-traits-are-object-safe-and-which-aint/90620/3
+// Playground:
+// https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=ba1fd8301dddf385f6f9f56b8316a4df
+
+pub trait DynClone {
+    fn dyn_clone(&self) -> Box<dyn RenderableCmd>;
+}
+
+impl<T: RenderableCmd + Clone + 'static> DynClone for T {
+    fn dyn_clone(&self) -> Box<dyn RenderableCmd> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<dyn RenderableCmd> {
+    fn clone(&self) -> Self {
+        (**self).dyn_clone()
+    }
+}

--- a/src/stub/preprocessor.rs
+++ b/src/stub/preprocessor.rs
@@ -1,12 +1,22 @@
-pub mod s_expressions;
+pub mod lisp_like;
 
 use dyn_clone::DynClone;
 
 use super::renderer::Renderer;
 use super::Stub;
 
+/// A function that transforms a stub.
+///
+/// The intended use case of these preprocessor functions is to rearrange Stub
+/// in order to add functionality through custom Renderable types.
 pub type Preprocessor = fn(&mut Stub) -> ();
 
+/// A type that provides custom rendering logic.
+///
+/// This is the primary method of extending the stub rendering system of coctus
+/// without affecting existing templates. Any type that implements this trait
+/// may be wrapped in Cmd::External and its render method will be called by
+/// Renderer.
 pub trait Renderable: std::fmt::Debug + DynClone {
     fn render(&self, renderer: &Renderer) -> String;
 }

--- a/src/stub/preprocessor.rs
+++ b/src/stub/preprocessor.rs
@@ -1,32 +1,14 @@
-use super::{renderer::Renderer, Stub};
+pub mod s_expressions;
 
-pub trait RenderableCmd: Renderable + std::fmt::Debug + DynClone {}
+use dyn_clone::DynClone;
 
-pub trait Renderable {
+use super::renderer::Renderer;
+use super::Stub;
+
+pub type Preprocessor = fn(&mut Stub) -> ();
+
+pub trait Renderable: std::fmt::Debug + DynClone {
     fn render(&self, renderer: &Renderer) -> String;
 }
 
-pub trait Preprocessor {
-    fn transform(stub: &mut Stub);
-}
-
-// Workaround for trait object to implement Clone:
-// https://users.rust-lang.org/t/how-to-deal-with-the-trait-cannot-be-made-into-an-object-error-in-rust-which-traits-are-object-safe-and-which-aint/90620/3
-// Playground:
-// https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=ba1fd8301dddf385f6f9f56b8316a4df
-
-pub trait DynClone {
-    fn dyn_clone(&self) -> Box<dyn RenderableCmd>;
-}
-
-impl<T: RenderableCmd + Clone + 'static> DynClone for T {
-    fn dyn_clone(&self) -> Box<dyn RenderableCmd> {
-        Box::new(self.clone())
-    }
-}
-
-impl Clone for Box<dyn RenderableCmd> {
-    fn clone(&self) -> Self {
-        (**self).dyn_clone()
-    }
-}
+dyn_clone::clone_trait_object!(Renderable);

--- a/src/stub/preprocessor/lisp_like.rs
+++ b/src/stub/preprocessor/lisp_like.rs
@@ -1,6 +1,15 @@
 use super::Renderable;
 use crate::stub::{Cmd, Stub};
 
+/// Edit Stub to allow for rendering lisp-like syntax.
+///
+/// Specifically, this preprocessor will:
+/// - batch consecutive reads together
+/// - embed remaining commands inside the scope of a read_batch
+///
+/// The purpose is to support languages such as lisp and clojure which
+/// initialize multiple variables in one statement and also must have the scope
+/// of said variables explicitly wrapped.
 pub fn transform(stub: &mut Stub) {
     let mut old_commands = stub.commands.drain(..).rev().peekable();
 

--- a/src/stub/preprocessor/s_expressions.rs
+++ b/src/stub/preprocessor/s_expressions.rs
@@ -1,0 +1,63 @@
+use super::Renderable;
+use crate::stub::{Cmd, Stub, VariableCommand};
+
+pub fn transform(stub: &mut Stub) {
+    let old_commands = stub.commands.drain(..).peekable();
+
+    let (mut cmds, mut leftover) = old_commands.rev().fold((vec![], vec![]), |(mut cmds, mut reads), cmd| {
+        if matches!(cmd, Cmd::Read(_)) {
+            reads.push(cmd)
+        } else {
+            if !reads.is_empty() {
+                let read_batch = ReadBatch::new(reads.drain(..).collect(), cmds.drain(..).collect());
+
+                cmds.push(Cmd::External(Box::new(read_batch)));
+            }
+
+            cmds.push(cmd);
+        }
+
+        (cmds, reads)
+    });
+
+    if !leftover.is_empty() {
+        let read_batch = ReadBatch::new(leftover.drain(..).collect(), cmds.drain(..).collect());
+
+        cmds.push(Cmd::External(Box::new(read_batch)));
+    }
+
+    stub.commands = cmds;
+    stub.commands.reverse();
+}
+
+#[derive(Debug, Clone)]
+struct ReadBatch {
+    pub line_readers: Vec<Cmd>,
+    pub nested_cmds: Vec<Cmd>,
+}
+
+impl ReadBatch {
+    fn new(line_readers: Vec<Cmd>, nested_cmds: Vec<Cmd>) -> ReadBatch {
+        ReadBatch {
+            line_readers,
+            nested_cmds,
+        }
+    }
+}
+
+impl Renderable for ReadBatch {
+    fn render(&self, renderer: &crate::stub::renderer::Renderer) -> String {
+        let nested_string: String =
+            self.nested_cmds.iter().map(|cmd| renderer.render_command(cmd, 0)).collect();
+        let nested_lines: Vec<&str> = nested_string.lines().collect();
+
+        let read_lines: String =
+            self.line_readers.iter().map(|cmd| renderer.render_command(cmd, 0)).collect();
+        let read_lines: Vec<&str> = read_lines.lines().collect();
+
+        let mut context = tera::Context::new();
+        context.insert("read_lines", &read_lines);
+        context.insert("nested_lines", &nested_lines);
+        renderer.tera_render("read_batch", &mut context)
+    }
+}

--- a/src/stub/renderer.rs
+++ b/src/stub/renderer.rs
@@ -14,7 +14,7 @@ pub fn render_stub(config: StubConfig, stub: Stub) -> Result<String> {
     Ok(renderer.render())
 }
 
-struct Renderer {
+pub struct Renderer {
     tera: Tera,
     lang: Language,
     stub: Stub,
@@ -62,7 +62,7 @@ impl Renderer {
         self.tera_render("main", &mut context)
     }
 
-    fn render_command(&self, cmd: &Cmd, nesting_depth: usize) -> String {
+    pub fn render_command(&self, cmd: &Cmd, nesting_depth: usize) -> String {
         match cmd {
             Cmd::Read(vars) => self.render_read(vars, nesting_depth),
             Cmd::Write {
@@ -76,6 +76,9 @@ impl Renderer {
             Cmd::Loop { count_var, command } => self.render_loop(count_var, command, nesting_depth),
             Cmd::LoopLine { count_var, variables } => {
                 self.render_loopline(count_var, variables, nesting_depth)
+            },
+            Cmd::External(cmd) => {
+                cmd.render(self)
             }
         }
     }

--- a/src/stub/renderer.rs
+++ b/src/stub/renderer.rs
@@ -29,7 +29,7 @@ impl Renderer {
         })
     }
 
-    fn tera_render(&self, template_name: &str, context: &mut Context) -> String {
+    pub fn tera_render(&self, template_name: &str, context: &mut Context) -> String {
         // Since these are (generally) shared across languages, it makes sense to
         // store it in the "global" context instead of accepting it as parameters.
         let format_symbols = json!({
@@ -76,10 +76,8 @@ impl Renderer {
             Cmd::Loop { count_var, command } => self.render_loop(count_var, command, nesting_depth),
             Cmd::LoopLine { count_var, variables } => {
                 self.render_loopline(count_var, variables, nesting_depth)
-            },
-            Cmd::External(cmd) => {
-                cmd.render(self)
             }
+            Cmd::External(cmd) => cmd.render(self),
         }
     }
 


### PR DESCRIPTION
Languages like lisp, clojure, or webassembly have [S-Expression](https://en.wikipedia.org/wiki/S-expression) syntax which cannot be generated from the current way we store stubs.