### PR TITLE
Simplify stub module public API

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -474,7 +474,8 @@ impl App {
         };
 
         // Language config files are stored in: (ordered by precedence)
-        // 1. The user config dir: `stub_templates/LANG/stub_config.toml`
+        // 1. The user config dir, where {CONF} is the OS dependent config folder:
+        //    `{CONF}/stub_templates/LANG/stub_config.toml`
         // 2. This repo, embedded into the binary:
         //    `config/stub_templates/LANG/stub_config.toml`
         let lang_template_dir = self.stub_templates_dir.join(lang_arg);

--- a/src/stub.rs
+++ b/src/stub.rs
@@ -24,6 +24,17 @@ pub fn generate_from_config(config: StubConfig, generator: &str) -> Result<Strin
     Ok(output_str.as_str().trim().to_string())
 }
 
+/// Generate a stub string from a (supported) language and a generator.
+///
+/// # Examples
+///
+/// ```
+/// use clashlib::stub::generate;
+///
+/// let generator = "read anInt:int\nwrite solution";
+/// let stub_str = generate("python", generator).unwrap();
+/// assert_eq!(stub_str, "an_int = int(input())\nprint(\"solution\")");
+/// ```
 pub fn generate(language_name: &str, generator: &str) -> Result<String> {
     let config = StubConfig::read_from_embedded(language_name)?;
     generate_from_config(config, generator)

--- a/src/stub.rs
+++ b/src/stub.rs
@@ -1,35 +1,38 @@
-pub mod language;
+mod language;
 mod parser;
-pub mod preprocessor;
+mod preprocessor;
 mod renderer;
-pub mod stub_config;
+mod stub_config;
 
 use anyhow::Result;
 use indoc::indoc;
-pub use language::Language;
+use language::Language;
 use preprocessor::Renderable;
 use serde::Serialize;
 pub use stub_config::StubConfig;
 
-pub fn generate(config: StubConfig, generator: &str) -> Result<String> {
+pub fn generate_from_config(config: StubConfig, generator: &str) -> Result<String> {
     let mut stub = parser::parse_generator_stub(generator)?;
 
     if let Some(processor) = config.language.preprocessor {
         processor(&mut stub)
     }
 
-    // eprint!("=======\n{:?}\n======\n", generator);
-    // eprint!("=======\n{:?}\n======\n", stub);
-
-    let output_str = renderer::render_stub(config.clone(), stub)?;
+    let renderer = renderer::Renderer::new(config, stub)?;
+    let output_str = renderer.render();
 
     Ok(output_str.as_str().trim().to_string())
 }
 
+pub fn generate(language_name: &str, generator: &str) -> Result<String> {
+    let config = StubConfig::read_from_embedded(language_name)?;
+    generate_from_config(config, generator)
+}
+
 #[derive(Clone, Default)]
-pub struct Stub {
-    pub commands: Vec<Cmd>,
-    pub statement: Vec<String>,
+struct Stub {
+    commands: Vec<Cmd>,
+    statement: Vec<String>,
 }
 
 // More visual than derive(Debug)
@@ -44,7 +47,7 @@ impl std::fmt::Debug for Stub {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Hash)]
-pub enum VarType {
+enum VarType {
     Int,
     Float,
     Long,
@@ -74,11 +77,11 @@ impl<'a> VarType {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct VariableCommand {
-    pub ident: String,
-    pub var_type: VarType,
-    pub max_length: Option<String>,
-    pub input_comment: String,
+struct VariableCommand {
+    ident: String,
+    var_type: VarType,
+    max_length: Option<String>,
+    input_comment: String,
 }
 
 impl VariableCommand {
@@ -93,7 +96,7 @@ impl VariableCommand {
 }
 
 #[derive(Serialize, Clone, Debug)]
-pub struct JoinTerm {
+struct JoinTerm {
     pub ident: String,
     pub var_type: Option<VarType>,
 }
@@ -105,7 +108,7 @@ impl JoinTerm {
 }
 
 #[derive(Debug, Clone)]
-pub enum Cmd {
+enum Cmd {
     Read(Vec<VariableCommand>),
     Loop {
         count_var: String,
@@ -224,7 +227,7 @@ mod tests {
     fn test_simple_code_generation() {
         let cfg = StubConfig::read_from_embedded("ruby").unwrap();
         let generator = "read m:int n:int\nwrite result";
-        let received = generate(cfg, generator).unwrap();
+        let received = generate_from_config(cfg, generator).unwrap();
         let expected = "m, n = gets.split.map(&:to_i)\nputs \"result\"";
 
         assert_eq!(received, expected);
@@ -233,7 +236,7 @@ mod tests {
     #[test]
     fn test_reference_stub_ruby() {
         let cfg = StubConfig::read_from_embedded("ruby").unwrap();
-        let received = generate(cfg, COMPLEX_REFERENCE_STUB).unwrap();
+        let received = generate_from_config(cfg, COMPLEX_REFERENCE_STUB).unwrap();
         let expected = indoc! { r##"
             # Live long
             # and prosper
@@ -299,18 +302,18 @@ mod tests {
     #[test]
     fn test_reference_stub_rust() {
         let cfg = StubConfig::read_from_embedded("rust").unwrap();
-        generate(cfg, COMPLEX_REFERENCE_STUB).unwrap();
+        generate_from_config(cfg, COMPLEX_REFERENCE_STUB).unwrap();
     }
 
     #[test]
     fn test_reference_stub_c() {
         let cfg = StubConfig::read_from_embedded("c").unwrap();
-        generate(cfg, COMPLEX_REFERENCE_STUB).unwrap();
+        generate_from_config(cfg, COMPLEX_REFERENCE_STUB).unwrap();
     }
 
     #[test]
     fn test_reference_stub_cpp() {
         let cfg = StubConfig::read_from_embedded("cpp").unwrap();
-        generate(cfg, COMPLEX_REFERENCE_STUB).unwrap();
+        generate_from_config(cfg, COMPLEX_REFERENCE_STUB).unwrap();
     }
 }

--- a/src/stub.rs
+++ b/src/stub.rs
@@ -225,9 +225,8 @@ mod tests {
 
     #[test]
     fn test_simple_code_generation() {
-        let cfg = StubConfig::read_from_embedded("ruby").unwrap();
         let generator = "read m:int n:int\nwrite result";
-        let received = generate_from_config(cfg, generator).unwrap();
+        let received = generate("ruby", generator).unwrap();
         let expected = "m, n = gets.split.map(&:to_i)\nputs \"result\"";
 
         assert_eq!(received, expected);
@@ -235,8 +234,7 @@ mod tests {
 
     #[test]
     fn test_reference_stub_ruby() {
-        let cfg = StubConfig::read_from_embedded("ruby").unwrap();
-        let received = generate_from_config(cfg, COMPLEX_REFERENCE_STUB).unwrap();
+        let received = generate("ruby", COMPLEX_REFERENCE_STUB).unwrap();
         let expected = indoc! { r##"
             # Live long
             # and prosper
@@ -301,19 +299,16 @@ mod tests {
     // Just test that it compiles
     #[test]
     fn test_reference_stub_rust() {
-        let cfg = StubConfig::read_from_embedded("rust").unwrap();
-        generate_from_config(cfg, COMPLEX_REFERENCE_STUB).unwrap();
+        generate("rust", COMPLEX_REFERENCE_STUB).unwrap();
     }
 
     #[test]
     fn test_reference_stub_c() {
-        let cfg = StubConfig::read_from_embedded("c").unwrap();
-        generate_from_config(cfg, COMPLEX_REFERENCE_STUB).unwrap();
+        generate("c", COMPLEX_REFERENCE_STUB).unwrap();
     }
 
     #[test]
     fn test_reference_stub_cpp() {
-        let cfg = StubConfig::read_from_embedded("cpp").unwrap();
-        generate_from_config(cfg, COMPLEX_REFERENCE_STUB).unwrap();
+        generate("cpp", COMPLEX_REFERENCE_STUB).unwrap();
     }
 }

--- a/src/stub/language.rs
+++ b/src/stub/language.rs
@@ -8,18 +8,17 @@ use super::preprocessor::{self, Preprocessor};
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "PascalCase")]
-pub struct TypeTokens {
-    pub int: Option<String>,
-    pub float: Option<String>,
-    pub long: Option<String>,
-    pub bool: Option<String>,
-    pub word: Option<String>,
-    pub string: Option<String>,
+pub(super) struct TypeTokens {
+    int: Option<String>,
+    float: Option<String>,
+    long: Option<String>,
+    bool: Option<String>,
+    word: Option<String>,
+    string: Option<String>,
 }
 
 #[derive(Deserialize, Clone, Debug)]
-pub struct Language {
-    pub name: String,
+pub(super) struct Language {
     pub variable_name_options: VariableNameOptions,
     pub source_file_ext: String,
     pub type_tokens: TypeTokens,

--- a/src/stub/language/variable_name_options.rs
+++ b/src/stub/language/variable_name_options.rs
@@ -6,7 +6,7 @@ use crate::stub::VariableCommand;
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
 #[allow(clippy::enum_variant_names)]
-pub enum Casing {
+enum Casing {
     SnakeCase,
     KebabCase,
     CamelCase,
@@ -16,9 +16,9 @@ pub enum Casing {
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct VariableNameOptions {
-    pub casing: Casing,
-    pub allow_uppercase_vars: Option<bool>,
-    pub keywords: Vec<String>,
+    casing: Casing,
+    allow_uppercase_vars: Option<bool>,
+    keywords: Vec<String>,
 }
 
 fn is_uppercase_string(string: &str) -> bool {
@@ -26,7 +26,7 @@ fn is_uppercase_string(string: &str) -> bool {
 }
 
 impl VariableNameOptions {
-    pub fn transform_variable_name(&self, variable_name: &str) -> String {
+    pub(in crate::stub) fn transform_variable_name(&self, variable_name: &str) -> String {
         // CG has special treatment for variables with all uppercase identifiers.
         // In most languages they remain uppercase regardless of variable format.
         // In others (such as ruby where constants are uppercase) they get downcased.
@@ -39,7 +39,7 @@ impl VariableNameOptions {
         self.escape_keywords(converted_variable_name)
     }
 
-    pub fn transform_variable_command(&self, var: &VariableCommand) -> VariableCommand {
+    pub(in crate::stub) fn transform_variable_command(&self, var: &VariableCommand) -> VariableCommand {
         VariableCommand {
             ident: self.transform_variable_name(&var.ident),
             var_type: var.var_type,
@@ -48,7 +48,7 @@ impl VariableNameOptions {
         }
     }
 
-    pub fn escape_keywords(&self, variable_name: String) -> String {
+    fn escape_keywords(&self, variable_name: String) -> String {
         if self.keywords.contains(&variable_name) {
             format!("_{variable_name}")
         } else {

--- a/src/stub/renderer.rs
+++ b/src/stub/renderer.rs
@@ -9,11 +9,6 @@ const ALPHABET: [char; 18] = [
     'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
 ];
 
-pub fn render_stub(config: StubConfig, stub: Stub) -> Result<String> {
-    let renderer = Renderer::new(config, stub)?;
-    Ok(renderer.render())
-}
-
 pub struct Renderer {
     tera: Tera,
     lang: Language,
@@ -21,7 +16,7 @@ pub struct Renderer {
 }
 
 impl Renderer {
-    fn new(config: StubConfig, stub: Stub) -> Result<Renderer> {
+    pub(super) fn new(config: StubConfig, stub: Stub) -> Result<Renderer> {
         Ok(Self {
             lang: config.language,
             tera: config.tera,
@@ -29,7 +24,7 @@ impl Renderer {
         })
     }
 
-    pub fn tera_render(&self, template_name: &str, context: &mut Context) -> String {
+    pub(super) fn tera_render(&self, template_name: &str, context: &mut Context) -> String {
         // Since these are (generally) shared across languages, it makes sense to
         // store it in the "global" context instead of accepting it as parameters.
         let format_symbols = json!({
@@ -50,7 +45,7 @@ impl Renderer {
             .unwrap()
     }
 
-    fn render(&self) -> String {
+    pub(super) fn render(&self) -> String {
         let mut context = Context::new();
 
         let code: String = self.stub.commands.iter().map(|cmd| self.render_command(cmd, 0)).collect();
@@ -62,7 +57,7 @@ impl Renderer {
         self.tera_render("main", &mut context)
     }
 
-    pub fn render_command(&self, cmd: &Cmd, nesting_depth: usize) -> String {
+    pub(super) fn render_command(&self, cmd: &Cmd, nesting_depth: usize) -> String {
         match cmd {
             Cmd::Read(vars) => self.render_read(vars, nesting_depth),
             Cmd::Write {

--- a/src/stub/stub_config.rs
+++ b/src/stub/stub_config.rs
@@ -6,7 +6,7 @@ use tera::Tera;
 
 use super::Language;
 
-const HARDCODED_TEMPLATE_DIR: include_dir::Dir<'static> =
+const HARDCODED_EMBEDDED_TEMPLATE_DIR: include_dir::Dir<'static> =
     include_dir!("$CARGO_MANIFEST_DIR/config/stub_templates");
 
 #[derive(Clone)]
@@ -17,8 +17,8 @@ pub struct StubConfig {
 
 impl StubConfig {
     pub fn read_from_dir(dir: std::path::PathBuf) -> Result<Self> {
-        let fname = dir.join("stub_config.toml");
-        let toml_str = fs::read_to_string(fname)?;
+        let toml_file = dir.join("stub_config.toml");
+        let toml_str = fs::read_to_string(toml_file)?;
         let language: Language = toml::from_str(&toml_str)?;
         let jinja_glob = dir.join("*.jinja");
         let tera = Tera::new(jinja_glob.to_str().expect("language directory path should be valid utf8"))
@@ -30,13 +30,13 @@ impl StubConfig {
         // If you just created a new template for a language and you get:
         // Error: No stub generator found for 'language'
         // you may need to recompile the binaries to update: `cargo build`
-        let embedded_config_dir = HARDCODED_TEMPLATE_DIR
+        let embedded_config_dir = HARDCODED_EMBEDDED_TEMPLATE_DIR
             .get_dir(lang_name)
             .context(format!("No stub generator found for '{lang_name}'"))?;
-        let config_file = embedded_config_dir
+        let toml_file = embedded_config_dir
             .get_file(format!("{lang_name}/stub_config.toml"))
             .expect("Embedded stub generators should have stub_config.toml");
-        let toml_str = config_file
+        let toml_str = toml_file
             .contents_utf8()
             .expect("Embedded stub_config.toml contents should be valid utf8");
         let language: Language = toml::from_str(toml_str)?;

--- a/src/stub/stub_config.rs
+++ b/src/stub/stub_config.rs
@@ -26,7 +26,7 @@ impl StubConfig {
         Ok(Self { language, tera })
     }
 
-    pub fn read_from_embedded(lang_name: &str) -> Result<Self> {
+    pub(super) fn read_from_embedded(lang_name: &str) -> Result<Self> {
         // If you just created a new template for a language and you get:
         // Error: No stub generator found for 'language'
         // you may need to recompile the binaries to update: `cargo build`

--- a/src/stub/stub_config.rs
+++ b/src/stub/stub_config.rs
@@ -1,5 +1,4 @@
 use std::fs;
-use std::path::Path;
 
 use anyhow::{Context, Result};
 use include_dir::include_dir;
@@ -12,32 +11,11 @@ const HARDCODED_TEMPLATE_DIR: include_dir::Dir<'static> =
 
 #[derive(Clone)]
 pub struct StubConfig {
-    pub language: Language,
-    pub tera: Tera,
+    pub(super) language: Language,
+    pub(super) tera: Tera,
 }
 
 impl StubConfig {
-    /// This function is responsible for searching locations where language
-    /// config files can be stored.
-    ///
-    /// Language config files are stored in: (ordered by precedence)
-    /// 1. The user config dir: `stub_templates/#{lang_arg}/stub_config.toml`
-    /// 2. This repo, embedded into the binary:
-    ///    `config/stub_templates/#{lang_arg}/stub_config.toml`
-    ///
-    /// where the user config dir is in `~/.config/coctus` (Linux, see the
-    /// [directories documentation](https://docs.rs/directories/latest/directories/struct.ProjectDirs.html#method.config_dir)
-    /// for others).
-    pub fn find_stub_config(lang_name: &str, config_path: &Path) -> Result<Self> {
-        let user_config_lang_dir = config_path.join(lang_name);
-
-        if user_config_lang_dir.is_file() {
-            Self::read_from_dir(user_config_lang_dir)
-        } else {
-            Self::read_from_embedded(&lang_name.to_lowercase())
-        }
-    }
-
     pub fn read_from_dir(dir: std::path::PathBuf) -> Result<Self> {
         let fname = dir.join("stub_config.toml");
         let toml_str = fs::read_to_string(fname)?;

--- a/tests/render_py_tests.rs
+++ b/tests/render_py_tests.rs
@@ -1,8 +1,7 @@
-use clashlib::stub::{self, StubConfig};
+use clashlib::stub;
 
 fn test_stub_builder(generator: &str, expected: &str) {
-    let cfg = StubConfig::read_from_embedded("python").unwrap();
-    let received = stub::generate_from_config(cfg, generator).unwrap().as_str().trim().to_string();
+    let received = stub::generate("python", generator).unwrap().as_str().trim().to_string();
     let expected = expected.trim();
 
     assert_eq!(expected.lines().count(), received.lines().count());

--- a/tests/render_py_tests.rs
+++ b/tests/render_py_tests.rs
@@ -2,7 +2,7 @@ use clashlib::stub::{self, StubConfig};
 
 fn test_stub_builder(generator: &str, expected: &str) {
     let cfg = StubConfig::read_from_embedded("python").unwrap();
-    let received = stub::generate(cfg, generator).unwrap().as_str().trim().to_string();
+    let received = stub::generate_from_config(cfg, generator).unwrap().as_str().trim().to_string();
     let expected = expected.trim();
 
     assert_eq!(expected.lines().count(), received.lines().count());


### PR DESCRIPTION
I made most of the implementation details internal to the module. It could probably use some more refactoring but I think this is at least a step in the right direction.

These are still public:
* `stub::generate` :+1: 
* `stub::generate_from_config` :thinking: 
* `stub::StubConfig` :thinking: 
  - `read_from_dir` :thinking: 
* `stub::SIMPLE_REFERENCE_STUB` :thinking: 
