### PR TITLE
Make test_helper both accessible to main.rs and lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,7 @@ pub mod clash;
 pub mod solution;
 pub mod stub;
 
-#[cfg(test)]
-pub mod test_helper;
+// Used to quickly load fixtures. Not public API.
+#[doc(hidden)]
+#[path = "test_helper.rs"]
+pub mod __test_helper;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 mod internal;
-
 use std::io::Read;
 use std::path::PathBuf;
 use std::process::Command;
@@ -9,7 +8,7 @@ use anyhow::{anyhow, Context, Result};
 use clap::ArgMatches;
 use clashlib::clash::{Clash, PublicHandle, Testcase};
 use clashlib::stub::StubConfig;
-use clashlib::{solution, stub};
+use clashlib::{__test_helper, solution, stub};
 use directories::ProjectDirs;
 use internal::OutputStyle;
 use rand::seq::IteratorRandom;
@@ -464,7 +463,12 @@ impl App {
                 input
             }
             Some(fname) => std::fs::read_to_string(fname)?,
-            None if args.get_flag("from-reference") => stub::SIMPLE_REFERENCE_STUB.to_owned(),
+            None if args.get_flag("from-reference") => {
+                let reference_clash = __test_helper::sample_puzzle("stub_and_solution_tester").unwrap();
+                let reference_stub = reference_clash.stub_generator().unwrap();
+
+                reference_stub.to_owned()
+            }
             None => {
                 let handle = self.current_handle()?;
                 self.read_clash(&handle)?

--- a/src/solution.rs
+++ b/src/solution.rs
@@ -95,7 +95,7 @@ mod tests {
 
     #[test]
     fn test_passing_solution() {
-        let clash = crate::test_helper::sample_puzzle("stub_and_solution_tester").unwrap();
+        let clash = crate::__test_helper::sample_puzzle("stub_and_solution_tester").unwrap();
         let mut run_cmd = Command::new("tr");
         run_cmd.arg("X");
         run_cmd.arg("b");
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn test_failing_solution() {
-        let clash = crate::test_helper::sample_puzzle("stub_and_solution_tester").unwrap();
+        let clash = crate::__test_helper::sample_puzzle("stub_and_solution_tester").unwrap();
         let timeout = Duration::from_secs(1);
         let mut run_cmd = Command::new("cat");
         assert!(lazy_run(clash.testcases(), &mut run_cmd, &timeout)

--- a/src/stub.rs
+++ b/src/stub.rs
@@ -5,7 +5,6 @@ mod renderer;
 mod stub_config;
 
 use anyhow::Result;
-use indoc::indoc;
 use language::Language;
 use preprocessor::Renderable;
 use serde::Serialize;
@@ -140,39 +139,10 @@ enum Cmd {
     External(Box<dyn Renderable>),
 }
 
-pub const SIMPLE_REFERENCE_STUB: &str = indoc! {r##"
-    read anInt:int
-    read aFloat:float
-    read Long:long
-    read aWord:word(1)
-    read boolean:bool
-    read ABC1ABc1aBC1AbC1abc1:int
-    read STRING:string(256)
-    read anInt2:int aFloat2:float Long2:long aWord2:word(1) boolean2:bool
-    loop anInt read x:int
-    loop anInt read x:int f:float
-    loop anInt loop anInt read x:int y:int
-    loopline anInt x:int
-    loopline anInt w:word(50)
-    loopline anInt x:int f:float w:word(50)
-    write result
-
-    OUTPUT
-    An output comment
-
-    write join(anInt, aFloat, Long, boolean)
-
-    write join(aWord, "literal", STRING)
-
-    STATEMENT
-    This is the statement
-
-    INPUT
-    anInt: An input comment over anInt
-"##};
-
 #[cfg(test)]
 mod tests {
+    use indoc::indoc;
+
     use super::*;
 
     const COMPLEX_REFERENCE_STUB: &str = indoc! {r##"


### PR DESCRIPTION
From [this](https://stackoverflow.com/questions/73544273/having-both-public-and-private-code-shared-between-multiple-binaries-rust) idea.

This:
- Gets rid of Stub::SIMPLE_REFERENCE.
- Exports as pub test_helper but should be obvious that it's not intended for public use.
- Allows for easier synchronization between CG and the reference test (Ideally a quick script to update the json should be located on fixtures/puzzles?).

NOTE: In the future, the reference fixture, and the fixture used now for solution.rs should ideally be separated.

Maybe `fixture_loader` is a more suggestive name than `test_helper`.